### PR TITLE
🔀 :: [#14] - gitignore에 dcd 빌드파일 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .idea
+
+dcd
+dcd-info
+
+.DS_Store


### PR DESCRIPTION
## 개요
* gitignore에 dcd 빌드파일을 추가합니다.
## 작업내용
* gitignore에 dcd 빌드파일 추가
* gitignore에 dcd-info 디렉토리 추가
* gitignore에 .DS_store 추가