### PR TITLE
🔀 :: [#6] - create 구현부 추가

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -1,0 +1,88 @@
+package exec
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/dolong2/dcd-cli/api"
+	"os"
+)
+
+type metaData struct {
+	ResourceType string `json:"resourceType"`
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+}
+
+type parsingMetaData struct {
+	Metadata metaData `json:"metadata"`
+}
+
+type workspaceTemplate struct {
+	Metadata metaData `json:"metadata"`
+}
+
+type workspaceRequest struct {
+	ResourceType string `json:"resourceType"`
+	Name         string `json:"title"`
+	Description  string `json:"description"`
+}
+
+func CreateByPath(fileDirectory string) error {
+	content, err := os.ReadFile(fileDirectory)
+	if err != nil {
+		return err
+	}
+
+	err = create(content)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func CreateByTemplate(rawTemplate string) error {
+	err := create([]byte(rawTemplate))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func create(content []byte) error {
+	var data parsingMetaData
+	err := json.Unmarshal(content, &data)
+	if err != nil {
+		return err
+	}
+
+	header := make(map[string]string)
+	token, err := GetAccessToken()
+	header["Authorization"] = "Bearer " + token
+	if err != nil {
+		return err
+	}
+
+	resourceType := data.Metadata.ResourceType
+	if resourceType == "WORKSPACE" {
+		var workspace workspaceTemplate
+		err = json.Unmarshal(content, &workspace)
+		if err != nil {
+			return err
+		}
+
+		request, err := json.Marshal(workspaceRequest{Name: workspace.Metadata.Name, Description: workspace.Metadata.Description})
+		if err != nil {
+			return err
+		}
+
+		_, err = api.SendPost("/workspace", header, request)
+		if err != nil {
+			return err
+		}
+	} else {
+		return errors.New(" this resource type is not supported")
+	}
+
+	return nil
+}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/dolong2/dcd-cli/api"
 	"os"
+	"strconv"
 )
 
 type metaData struct {
@@ -25,6 +26,26 @@ type workspaceRequest struct {
 	ResourceType string `json:"resourceType"`
 	Name         string `json:"title"`
 	Description  string `json:"description"`
+}
+
+type applicationTemplate struct {
+	Metadata        metaData          `json:"metadata"`
+	WorkspaceId     int64             `json:"workspaceId"`
+	GithubUrl       string            `json:"githubUrl"`
+	Env             map[string]string `json:"env"`
+	ApplicationType string            `json:"applicationType"`
+	Port            int               `json:"port"`
+	Version         string            `json:"version"`
+}
+
+type applicationRequest struct {
+	Name            string            `json:"title"`
+	Description     string            `json:"description"`
+	GithubUrl       string            `json:"githubUrl"`
+	Env             map[string]string `json:"env"`
+	ApplicationType string            `json:"applicationType"`
+	Port            int               `json:"port"`
+	Version         string            `json:"version"`
 }
 
 func CreateByPath(fileDirectory string) error {
@@ -77,6 +98,30 @@ func create(content []byte) error {
 		}
 
 		_, err = api.SendPost("/workspace", header, request)
+		if err != nil {
+			return err
+		}
+	} else if resourceType == "APPLICATION" {
+		var application applicationTemplate
+		err := json.Unmarshal(content, &application)
+		if err != nil {
+			return err
+		}
+
+		request, err := json.Marshal(applicationRequest{
+			Name:            application.Metadata.Name,
+			Description:     application.Metadata.Description,
+			GithubUrl:       application.GithubUrl,
+			Env:             application.Env,
+			ApplicationType: application.ApplicationType,
+			Port:            application.Port,
+			Version:         application.Version,
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = api.SendPost("/application/"+strconv.FormatInt(application.WorkspaceId, 10), header, request)
 		if err != nil {
 			return err
 		}

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -1,10 +1,9 @@
-package helper
+package exec
 
 import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dolong2/dcd-cli/api/exec"
 	"os"
 	"time"
 )
@@ -47,7 +46,7 @@ getTokenInfo:
 	// AccessToken이 만료되었을때 토큰 재발급
 	now := time.Now().Local()
 	if now.After(accessTokenExp) {
-		err := exec.ReissueToken(raw["refreshToken"].(string))
+		err := ReissueToken(raw["refreshToken"].(string))
 		if err != nil {
 			return "", err
 		}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/spf13/cobra"
 )
@@ -23,13 +24,17 @@ var createCmd = &cobra.Command{
 			err := cmdError.NewCmdError(1, "there must be required either file flag or template flag")
 			return err
 		} else if fileDirectory != "" {
-			//TODO 실제로 리소스 생성요청을 보내는 메서드 호출
-			fmt.Println(fileDirectory)
+			err := exec.CreateByPath(fileDirectory)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
 		} else if template != "" {
-			//TODO 실제로 리소스 생성요청을 보내는 메서드 호출
-			fmt.Println(template)
+			err := exec.CreateByTemplate(template)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
 		}
-		fmt.Println("create called")
+		fmt.Println("Successfully created resource!")
 		return nil
 	},
 }


### PR DESCRIPTION
## 개요
* 실제로 리소스를 생성하는 구현부를 추가합니다.
## 작업내용
* util.go를 helper 디렉토리에서 api/exec 디렉토리로 이동
* workspace 생성 로직 추가
* application 생성 로직 추가
* create 커맨드에서 create 실행 로직을 호출하도록 수정