### PR TITLE
🔀 :: [#21] - workspaces 커맨드에 id 플래그 추가

### DIFF
--- a/api/exec/get_workspace.go
+++ b/api/exec/get_workspace.go
@@ -36,3 +36,25 @@ func GetWorkspaces() (*WorkspaceListResponse, error) {
 
 	return &workspaceListResponse, nil
 }
+
+func GetWorkspace(id string) (*WorkspaceResponse, error) {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	response, err := api.SendGet("/workspace/"+id, header)
+	if err != nil {
+		return nil, err
+	}
+
+	var workspaceResponse WorkspaceResponse
+	err = json.Unmarshal(response, &workspaceResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workspaceResponse, nil
+}

--- a/api/exec/get_workspace.go
+++ b/api/exec/get_workspace.go
@@ -15,7 +15,7 @@ type WorkspaceResponse struct {
 	Description string `json:"description"`
 }
 
-func GetWorkspace() (*WorkspaceListResponse, error) {
+func GetWorkspaces() (*WorkspaceListResponse, error) {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -12,11 +12,20 @@ var workspacesCmd = &cobra.Command{
 	Short: "sub command to get workspaces",
 	Long:  `this command can be used to get workspaces`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err != nil {
-			fmt.Println(err)
-		}
-		for _, workspace := range workspaceList.List {
+		id, existsFlagErr := cmd.Flags().GetString("id")
+		if id == "" || existsFlagErr != nil {
 			workspaceList, err := exec.GetWorkspaces()
+			if err != nil {
+				fmt.Println(err)
+			}
+			for _, workspace := range workspaceList.List {
+				fmt.Printf("ID: %s\nTitle: %s\nDescription: %s\n\n", workspace.Id, workspace.Title, workspace.Description)
+			}
+		} else {
+			workspace, err := exec.GetWorkspace(id)
+			if err != nil {
+				fmt.Println(err)
+			}
 			fmt.Printf("ID: %s\nTitle: %s\nDescription: %s\n\n", workspace.Id, workspace.Title, workspace.Description)
 		}
 	},

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -12,11 +12,11 @@ var workspacesCmd = &cobra.Command{
 	Short: "sub command to get workspaces",
 	Long:  `this command can be used to get workspaces`,
 	Run: func(cmd *cobra.Command, args []string) {
-		workspaceList, err := exec.GetWorkspace()
 		if err != nil {
 			fmt.Println(err)
 		}
 		for _, workspace := range workspaceList.List {
+			workspaceList, err := exec.GetWorkspaces()
 			fmt.Printf("ID: %s\nTitle: %s\nDescription: %s\n\n", workspace.Id, workspace.Title, workspace.Description)
 		}
 	},

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -24,4 +24,5 @@ var workspacesCmd = &cobra.Command{
 
 func init() {
 	getCmd.AddCommand(workspacesCmd)
+	workspacesCmd.Flags().StringP("id", "", "", "use this flag to get a workspace by ID")
 }


### PR DESCRIPTION
## 개요
* workspaces 커맨드에 --id 플래그를 추가해서 단일 워크스페이스를 조회할 수 있게 합니다.
## 작업내용
* 워크스페이스 전체 조회 메서드 네이밍 수정
* id 플래그 추가
* GetWorkspace 메서드 추가
* id 플래그가 존재할때 단일 워크스페이스만 조회하도록 수정