### PR TITLE
🔀 :: [#25] - 최근에 추가된 서브 커맨드 리펙토링

### DIFF
--- a/cmd/applications.go
+++ b/cmd/applications.go
@@ -23,20 +23,7 @@ var applicationsCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, err.Error())
 		}
 		for _, application := range applicationListResponse.Applications {
-			fmt.Printf("ID: %s\n", application.Id)
-			fmt.Printf("Name: %s\n", application.Name)
-			fmt.Printf("Description: %s\n", application.Description)
-			fmt.Printf("Application Type: %s\n", application.ApplicationType)
-			fmt.Printf("GitHub URL: %s\n", application.GithubUrl)
-			fmt.Printf("Environment Variables: [\n")
-			for key, value := range application.Env {
-				fmt.Printf("  %s: %s\n", key, value)
-			}
-			fmt.Printf("]\n")
-			fmt.Printf("Port: %d\n", application.Port)
-			fmt.Printf("External Port: %d\n", application.ExternalPort)
-			fmt.Printf("Version: %s\n", application.Version)
-			fmt.Printf("Status: %s\n", application.Status)
+			printApplication(application)
 		}
 		return nil
 	},
@@ -45,4 +32,23 @@ var applicationsCmd = &cobra.Command{
 func init() {
 	getCmd.AddCommand(applicationsCmd)
 	applicationsCmd.Flags().StringP("workspace", "w", "", "use to identify workspace")
+}
+
+func printApplication(application exec.ApplicationResponse) {
+	fmt.Printf("ID: %s\n", application.Id)
+	fmt.Printf("Name: %s\n", application.Name)
+	fmt.Printf("Description: %s\n", application.Description)
+	fmt.Printf("Application Type: %s\n", application.ApplicationType)
+	fmt.Printf("GitHub URL: %s\n", application.GithubUrl)
+	fmt.Printf("Environment Variables: [\n")
+	for key, value := range application.Env {
+		fmt.Printf("  %s: %s\n", key, value)
+	}
+	fmt.Printf("]\n")
+	fmt.Printf("Port: %d\n", application.Port)
+	fmt.Printf("External Port: %d\n", application.ExternalPort)
+	fmt.Printf("Version: %s\n", application.Version)
+	fmt.Printf("Status: %s\n", application.Status)
+	fmt.Println()
+	fmt.Println()
 }

--- a/cmd/applications.go
+++ b/cmd/applications.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 
 	"github.com/spf13/cobra"
 )
@@ -12,14 +13,14 @@ var applicationsCmd = &cobra.Command{
 	Use:   "applications",
 	Short: "sub command to get applications",
 	Long:  `this command can be used to get workspaces`,
-	Run: func(cmd *cobra.Command, args []string) {
-		workspaceId, err2 := cmd.Flags().GetString("workspace")
-		if err2 != nil {
-			fmt.Println(err2)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, existsWorkspaceId := cmd.Flags().GetString("workspace")
+		if existsWorkspaceId != nil || workspaceId == "" {
+			return cmdError.NewCmdError(1, "requires workspace flag to get your applications")
 		}
 		applicationListResponse, err := exec.GetApplications(workspaceId)
 		if err != nil {
-			fmt.Println(err)
+			return cmdError.NewCmdError(1, err.Error())
 		}
 		for _, application := range applicationListResponse.Applications {
 			fmt.Printf("ID: %s\n", application.Id)
@@ -37,6 +38,7 @@ var applicationsCmd = &cobra.Command{
 			fmt.Printf("Version: %s\n", application.Version)
 			fmt.Printf("Status: %s\n", application.Status)
 		}
+		return nil
 	},
 }
 

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/spf13/cobra"
 )
 
@@ -11,12 +12,12 @@ var workspacesCmd = &cobra.Command{
 	Use:   "workspaces",
 	Short: "sub command to get workspaces",
 	Long:  `this command can be used to get workspaces`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		id, existsFlagErr := cmd.Flags().GetString("id")
 		if id == "" || existsFlagErr != nil {
 			workspaceList, err := exec.GetWorkspaces()
 			if err != nil {
-				fmt.Println(err)
+				return cmdError.NewCmdError(1, err.Error())
 			}
 			for _, workspace := range workspaceList.List {
 				fmt.Printf("ID: %s\nTitle: %s\nDescription: %s\n\n", workspace.Id, workspace.Title, workspace.Description)
@@ -24,10 +25,12 @@ var workspacesCmd = &cobra.Command{
 		} else {
 			workspace, err := exec.GetWorkspace(id)
 			if err != nil {
-				fmt.Println(err)
+				return cmdError.NewCmdError(1, err.Error())
 			}
 			fmt.Printf("ID: %s\nTitle: %s\nDescription: %s\n\n", workspace.Id, workspace.Title, workspace.Description)
 		}
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
## 개요
* 최근에 추가한 서브 커맨드(#23 #17)의 예외 처리 방식을 리펙토링합니다.
## 작업내용
* workspaces 서브 커맨드에서 에러 발생시 cmdError를 발생시키도록 수정
* applications 서브 커맨드에서 cmdError를 발생시키도록 수정
* 애플리케이션 정보를 출력하는 코드를 메서드로 분리