### PR TITLE
🔀 :: [#33] - api client 리펙토링

### DIFF
--- a/api/api_client.go
+++ b/api/api_client.go
@@ -178,3 +178,47 @@ func SendPatch(targetUrl string, header map[string]string, body []byte) ([]byte,
 
 	return result, nil
 }
+
+func sendHttpReq(method string, targetUrl string, header map[string]string, param []byte, body []byte) ([]byte, error) {
+	if len(param) != 0 {
+		targetUrl += "?"
+	}
+	for key, value := range param {
+		targetUrl += fmt.Sprintf("%s=%s&", key, value)
+	}
+
+	httpClient := &http.Client{}
+	request, err := http.NewRequest(method, baseUrl+targetUrl, bytes.NewBuffer(body))
+	if err != nil {
+		return []byte(""), err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	for key, value := range header {
+		request.Header.Set(key, value)
+	}
+
+	httpResponse, err := httpClient.Do(request)
+	if err != nil {
+		return []byte(""), err
+	}
+	defer httpResponse.Body.Close()
+
+	// 200번대 응답코드가 아닐때 에러
+	if httpResponse.StatusCode/100 != 2 {
+		rawErrorResponse, err := io.ReadAll(httpResponse.Body)
+		if err != nil {
+			return []byte(""), err
+		}
+		errorResponse := apiErrorResponse{}
+		json.Unmarshal(rawErrorResponse, &errorResponse)
+		return []byte(""), httpErr.NewHttpError(errorResponse.Status, errorResponse.Message)
+	}
+
+	result, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	return result, nil
+}

--- a/api/api_client.go
+++ b/api/api_client.go
@@ -17,42 +17,7 @@ type apiErrorResponse struct {
 }
 
 func SendGet(targetUrl string, header map[string]string, param map[string]string) ([]byte, error) {
-	httpClient := &http.Client{}
-	if len(param) != 0 {
-		targetUrl += "?"
-	}
-	for key, value := range param {
-		targetUrl += fmt.Sprintf("%s=%s&", key, value)
-	}
-
-	request, err := http.NewRequest("GET", baseUrl+targetUrl, bytes.NewBuffer([]byte("")))
-	if err != nil {
-		return []byte(""), err
-	}
-
-	request.Header.Set("Content-Type", "application/json")
-	for key, value := range header {
-		request.Header.Set(key, value)
-	}
-
-	httpResponse, err := httpClient.Do(request)
-	if err != nil {
-		return []byte(""), err
-	}
-	defer httpResponse.Body.Close()
-
-	// 200번대 응답코드가 아닐때 에러
-	if httpResponse.StatusCode/100 != 2 {
-		rawErrorResponse, err := io.ReadAll(httpResponse.Body)
-		if err != nil {
-			return []byte(""), err
-		}
-		errorResponse := apiErrorResponse{}
-		json.Unmarshal(rawErrorResponse, &errorResponse)
-		return []byte(""), httpErr.NewHttpError(errorResponse.Status, errorResponse.Message)
-	}
-
-	result, err := io.ReadAll(httpResponse.Body)
+	result, err := sendHttpReq("GET", targetUrl, header, param, []byte(""))
 	if err != nil {
 		return []byte(""), err
 	}
@@ -61,35 +26,7 @@ func SendGet(targetUrl string, header map[string]string, param map[string]string
 }
 
 func SendPost(targetUrl string, header map[string]string, body []byte) ([]byte, error) {
-	httpClient := &http.Client{}
-	request, err := http.NewRequest("POST", baseUrl+targetUrl, bytes.NewBuffer(body))
-	if err != nil {
-		return []byte(""), err
-	}
-
-	request.Header.Set("Content-Type", "application/json")
-	for key, value := range header {
-		request.Header.Set(key, value)
-	}
-
-	httpResponse, err := httpClient.Do(request)
-	if err != nil {
-		return []byte(""), err
-	}
-	defer httpResponse.Body.Close()
-
-	// 200번대 응답코드가 아닐때 에러
-	if httpResponse.StatusCode/100 != 2 {
-		rawErrorResponse, err := io.ReadAll(httpResponse.Body)
-		if err != nil {
-			return []byte(""), err
-		}
-		errorResponse := apiErrorResponse{}
-		json.Unmarshal(rawErrorResponse, &errorResponse)
-		return []byte(""), httpErr.NewHttpError(errorResponse.Status, errorResponse.Message)
-	}
-
-	result, err := io.ReadAll(httpResponse.Body)
+	result, err := sendHttpReq("POST", targetUrl, header, map[string]string{}, body)
 	if err != nil {
 		return []byte(""), err
 	}
@@ -98,43 +35,7 @@ func SendPost(targetUrl string, header map[string]string, body []byte) ([]byte, 
 }
 
 func SendDelete(targetUrl string, header map[string]string, param map[string]string) ([]byte, error) {
-	httpClient := &http.Client{}
-
-	if len(param) != 0 {
-		targetUrl += "?"
-	}
-	for key, value := range param {
-		targetUrl += fmt.Sprintf("%s=%s&", key, value)
-	}
-
-	request, err := http.NewRequest("DELETE", baseUrl+targetUrl, bytes.NewBuffer([]byte("")))
-	if err != nil {
-		return []byte(""), err
-	}
-
-	request.Header.Set("Content-Type", "application/json")
-	for key, value := range header {
-		request.Header.Set(key, value)
-	}
-
-	httpResponse, err := httpClient.Do(request)
-	if err != nil {
-		return []byte(""), err
-	}
-	defer httpResponse.Body.Close()
-
-	// 200번대 응답코드가 아닐때 에러
-	if httpResponse.StatusCode/100 != 2 {
-		rawErrorResponse, err := io.ReadAll(httpResponse.Body)
-		if err != nil {
-			return []byte(""), err
-		}
-		errorResponse := apiErrorResponse{}
-		json.Unmarshal(rawErrorResponse, &errorResponse)
-		return []byte(""), httpErr.NewHttpError(errorResponse.Status, errorResponse.Message)
-	}
-
-	result, err := io.ReadAll(httpResponse.Body)
+	result, err := sendHttpReq("DELETE", targetUrl, header, param, []byte(""))
 	if err != nil {
 		return []byte(""), err
 	}
@@ -143,35 +44,7 @@ func SendDelete(targetUrl string, header map[string]string, param map[string]str
 }
 
 func SendPatch(targetUrl string, header map[string]string, body []byte) ([]byte, error) {
-	httpClient := &http.Client{}
-	request, err := http.NewRequest("PATCH", baseUrl+targetUrl, bytes.NewBuffer(body))
-	if err != nil {
-		return []byte(""), err
-	}
-
-	request.Header.Set("Content-Type", "application/json")
-	for key, value := range header {
-		request.Header.Set(key, value)
-	}
-
-	httpResponse, err := httpClient.Do(request)
-	if err != nil {
-		return []byte(""), err
-	}
-	defer httpResponse.Body.Close()
-
-	// 200번대 응답코드가 아닐때 에러
-	if httpResponse.StatusCode/100 != 2 {
-		rawErrorResponse, err := io.ReadAll(httpResponse.Body)
-		if err != nil {
-			return []byte(""), err
-		}
-		errorResponse := apiErrorResponse{}
-		json.Unmarshal(rawErrorResponse, &errorResponse)
-		return []byte(""), httpErr.NewHttpError(errorResponse.Status, errorResponse.Message)
-	}
-
-	result, err := io.ReadAll(httpResponse.Body)
+	result, err := sendHttpReq("PATCH", targetUrl, header, map[string]string{}, body)
 	if err != nil {
 		return []byte(""), err
 	}
@@ -179,7 +52,7 @@ func SendPatch(targetUrl string, header map[string]string, body []byte) ([]byte,
 	return result, nil
 }
 
-func sendHttpReq(method string, targetUrl string, header map[string]string, param []byte, body []byte) ([]byte, error) {
+func sendHttpReq(method string, targetUrl string, header map[string]string, param map[string]string, body []byte) ([]byte, error) {
 	if len(param) != 0 {
 		targetUrl += "?"
 	}


### PR DESCRIPTION
## 개요
* http 요청을 보낼때 중복되는 부분을 메서드로 리펙토링합니다.
## 작업내용
* sendHttpReq 메서드 추가
* 각각의 http 메서드에 맞게 sendHttpReq를 호출하도록 변경