### PR TITLE
🔀 :: [#35] - env 커맨드를 일관성있게 수정

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,7 +28,6 @@ var addCmd = &cobra.Command{
 
 func init() {
 	envCmd.AddCommand(addCmd)
-	addCmd.Flags().StringP("application", "", "", "input application id")
 	addCmd.Flags().StringP("key", "k", "", "environment key")
 	addCmd.Flags().StringP("value", "v", "", "environment value")
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -12,11 +12,14 @@ var addCmd = &cobra.Command{
 	Short: "use to add an application env",
 	Long:  `this command can be used to add a env to an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		application, existsAppId := cmd.Flags().GetString("application")
+		if len(args) == 0 {
+			return cmdError.NewCmdError(1, "must specify applicationId")
+		}
+		application := args[0]
 		key, existsKey := cmd.Flags().GetString("key")
 		value, existsValue := cmd.Flags().GetString("value")
-		if application == "" || key == "" || value == "" || existsAppId != nil || existsKey != nil || existsValue != nil {
-			return cmdError.NewCmdError(1, "this command needs to specify both application and key and value")
+		if key == "" || value == "" || existsKey != nil || existsValue != nil {
+			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
 		}
 		err := exec.AddEnv(application, key, value)
 		if err != nil {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -8,7 +8,7 @@ import (
 
 // addCmd represents the add command
 var addCmd = &cobra.Command{
-	Use:   "add",
+	Use:   "add <applicationId> [flags]",
 	Short: "use to add an application env",
 	Long:  `this command can be used to add a env to an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -33,5 +33,5 @@ var rmCmd = &cobra.Command{
 func init() {
 	envCmd.AddCommand(rmCmd)
 
-	rmCmd.Flags().StringP("application", "", "", "select an application to delete env")
+	rmCmd.Flags().StringP("key", "", "", "select an key to delete")
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -8,7 +8,7 @@ import (
 
 // rmCmd represents the rm command
 var rmCmd = &cobra.Command{
-	Use:   "rm [envKey] [flags]",
+	Use:   "rm <applicationId> [flags]",
 	Short: "use to delete an application's env",
 	Long:  `this command is used to delete an application's env`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -13,12 +13,12 @@ var rmCmd = &cobra.Command{
 	Long:  `this command is used to delete an application's env`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "should specify envKey")
+			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
-		envKey := args[0]
-		applicationId, err := cmd.Flags().GetString("application")
-		if err != nil || applicationId == "" {
-			return cmdError.NewCmdError(1, "should specify applicationId")
+		applicationId := args[0]
+		envKey, err := cmd.Flags().GetString("key")
+		if err != nil || envKey == "" {
+			return cmdError.NewCmdError(1, "should specify envKey")
 		}
 
 		err = exec.RemoveEnv(applicationId, envKey)


### PR DESCRIPTION
## 개요
* env 커맨드의 사용법을 일관성있게 수정합니다.
## 작업내용
* env-add 커맨드의 Use 내용 수정
* env-add 커맨드의 application 플래그 제거
* 커맨드의 args를 이용해서 애플리케이션 아이디를 입력받도록 수정
* env-rm 커맨드의 Use 내용 수정
* env-rm 커맨드의 application 플래그를 key 플래그로 수정