### PR TITLE
🔀 :: [#41] - yaml 파일을 파싱할 수 있도록 수정

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dolong2/dcd-cli/api"
 	"gopkg.in/yaml.v3"
 	"os"
+	"path/filepath"
 	"strconv"
 )
 
@@ -55,11 +56,22 @@ func CreateByPath(fileDirectory string) error {
 		return err
 	}
 
-	err = create(content)
-	if err != nil {
-		return err
-	}
+	ext := filepath.Ext(fileDirectory)
+	switch ext {
+	case ".json":
 		err = createByJson(content)
+		if err != nil {
+			return err
+		}
+	case ".yml", ".yaml":
+		err = createByYml(content)
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("invalid file extension")
+	}
+
 	return nil
 }
 

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -58,11 +58,12 @@ func CreateByPath(fileDirectory string) error {
 	if err != nil {
 		return err
 	}
+		err = createByJson(content)
 	return nil
 }
 
 func CreateByTemplate(rawTemplate string) error {
-	err := create([]byte(rawTemplate))
+	err := createByJson([]byte(rawTemplate))
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func CreateByTemplate(rawTemplate string) error {
 	return nil
 }
 
-func create(content []byte) error {
+func createByJson(content []byte) error {
 	var data parsingMetaData
 	err := json.Unmarshal(content, &data)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,13 @@ module github.com/dolong2/dcd-cli
 go 1.21
 
 require (
+	github.com/spf13/cobra v1.8.0
+	golang.org/x/term v0.20.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.20.0 // indirect
-	golang.org/x/term v0.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,7 @@ golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.20.0 h1:VnkxpohqXaOBYJtBmEppKUG6mXpi+4O6purfc2+sMhw=
 golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## 개요
* yaml 파일을 파싱할 수 있는 로직을 추가합니다.
## 작업내용
* yaml 모듈 추가
* 기존의 create 메서드 네이밍을 createByJson 으로 수정
* createByYml 메서드 추가
* 파일 확장자 검증 로직 추가