### PR TITLE
🔀 :: [#52] - 애플리케이션에 접근할때 worksapceId를 사용하도록 변경

### DIFF
--- a/api/exec/add_env.go
+++ b/api/exec/add_env.go
@@ -10,7 +10,7 @@ type envRequest struct {
 	EnvList map[string]string `json:"envList"`
 }
 
-func AddEnv(applicationId string, key string, value string) error {
+func AddEnv(workspaceId string, applicationId string, key string, value string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -26,7 +26,7 @@ func AddEnv(applicationId string, key string, value string) error {
 	fmt.Println(envReq)
 	fmt.Println(string(requestJson))
 
-	_, err = api.SendPost("/application/"+applicationId+"/env", header, requestJson)
+	_, err = api.SendPost("/"+workspaceId+"/application/"+applicationId+"/env", header, requestJson)
 	if err != nil {
 		return err
 	}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -7,7 +7,6 @@ import (
 	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
-	"strconv"
 )
 
 type metaData struct {
@@ -135,7 +134,7 @@ func createByJson(content []byte) error {
 			return err
 		}
 
-		_, err = api.SendPost("/application/"+strconv.FormatInt(application.WorkspaceId, 10), header, request)
+		_, err = api.SendPost("/"+application.WorkspaceId+"application/", header, request)
 		if err != nil {
 			return err
 		}
@@ -197,7 +196,7 @@ func createByYml(content []byte) error {
 			return err
 		}
 
-		_, err = api.SendPost("/application/"+strconv.FormatInt(application.WorkspaceId, 10), header, request)
+		_, err = api.SendPost("/"+application.WorkspaceId+"/application/", header, request)
 		if err != nil {
 			return err
 		}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -32,7 +32,7 @@ type workspaceRequest struct {
 
 type applicationTemplate struct {
 	Metadata        metaData          `json:"metadata"`
-	WorkspaceId     int64             `json:"workspaceId"`
+	WorkspaceId     string            `json:"workspaceId"`
 	GithubUrl       string            `json:"githubUrl"`
 	Env             map[string]string `json:"env"`
 	ApplicationType string            `json:"applicationType"`

--- a/api/exec/deploy.go
+++ b/api/exec/deploy.go
@@ -2,7 +2,7 @@ package exec
 
 import "github.com/dolong2/dcd-cli/api"
 
-func DeployApplication(applicationId string) error {
+func DeployApplication(workspaceId string, applicationId string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -10,6 +10,6 @@ func DeployApplication(applicationId string) error {
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	_, err = api.SendPost("/application/"+applicationId+"/deploy", header, []byte(""))
+	_, err = api.SendPost("/"+workspaceId+"/application/"+applicationId+"/deploy", header, []byte(""))
 	return err
 }

--- a/api/exec/get_application.go
+++ b/api/exec/get_application.go
@@ -30,8 +30,7 @@ func GetApplications(workspaceId string) (*ApplicationListResponse, error) {
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	params := map[string]string{"workspaceId": workspaceId}
-	response, err := api.SendGet("/application", header, params)
+	response, err := api.SendGet("/"+workspaceId+"/application", header, map[string]string{})
 	if err != nil {
 		return nil, err
 	}

--- a/api/exec/get_application.go
+++ b/api/exec/get_application.go
@@ -44,7 +44,7 @@ func GetApplications(workspaceId string) (*ApplicationListResponse, error) {
 	return &applicationListResponse, nil
 }
 
-func GetApplication(applicationId string) (*ApplicationResponse, error) {
+func GetApplication(workspaceId string, applicationId string) (*ApplicationResponse, error) {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -52,7 +52,7 @@ func GetApplication(applicationId string) (*ApplicationResponse, error) {
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	response, err := api.SendGet("/application/"+applicationId, header, map[string]string{})
+	response, err := api.SendGet("/"+workspaceId+"/application/"+applicationId, header, map[string]string{})
 	if err != nil {
 		return nil, err
 	}

--- a/api/exec/remove_env.go
+++ b/api/exec/remove_env.go
@@ -4,7 +4,7 @@ import (
 	"github.com/dolong2/dcd-cli/api"
 )
 
-func RemoveEnv(applicationId string, envKey string) error {
+func RemoveEnv(workspaceId string, applicationId string, envKey string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -15,7 +15,7 @@ func RemoveEnv(applicationId string, envKey string) error {
 	params := make(map[string]string)
 	params["key"] = envKey
 
-	_, err = api.SendDelete("/application/"+applicationId+"/env", header, params)
+	_, err = api.SendDelete("/"+workspaceId+"/application/"+applicationId+"/env", header, params)
 	if err != nil {
 		return err
 	}

--- a/api/exec/run.go
+++ b/api/exec/run.go
@@ -1,8 +1,10 @@
 package exec
 
-import "github.com/dolong2/dcd-cli/api"
+import (
+	"github.com/dolong2/dcd-cli/api"
+)
 
-func RunApplication(applicationId string) error {
+func RunApplication(workspaceId string, applicationId string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -10,6 +12,6 @@ func RunApplication(applicationId string) error {
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	_, err = api.SendPost("/application/"+applicationId+"/run", header, []byte(""))
+	_, err = api.SendPost("/"+workspaceId+"/application/"+applicationId+"/run", header, []byte(""))
 	return err
 }

--- a/api/exec/stop.go
+++ b/api/exec/stop.go
@@ -2,7 +2,7 @@ package exec
 
 import "github.com/dolong2/dcd-cli/api"
 
-func StopApplication(applicationId string) error {
+func StopApplication(workspaceId string, applicationId string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -10,6 +10,6 @@ func StopApplication(applicationId string) error {
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	_, err = api.SendPost("/application/"+applicationId+"/stop", header, []byte(""))
+	_, err = api.SendPost("/"+workspaceId+"/application/"+applicationId+"/stop", header, []byte(""))
 	return err
 }

--- a/api/exec/update_env.go
+++ b/api/exec/update_env.go
@@ -5,7 +5,7 @@ import (
 	"github.com/dolong2/dcd-cli/api"
 )
 
-func UpdateEnv(applicationId string, key string, value string) error {
+func UpdateEnv(workspaceId string, applicationId string, key string, value string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -18,7 +18,7 @@ func UpdateEnv(applicationId string, key string, value string) error {
 	envReq := envRequest{EnvList: body}
 	requestJson, err := json.Marshal(envReq)
 
-	_, err = api.SendPatch("/application/"+applicationId+"/env/"+key, header, requestJson)
+	_, err = api.SendPatch("/"+workspaceId+"/application/"+applicationId+"/env/"+key, header, requestJson)
 	if err != nil {
 		return err
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,15 @@ var addCmd = &cobra.Command{
 	Short: "use to add an application env",
 	Long:  `this command can be used to add a env to an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId()
+		if err != nil {
+			workspaceFlag, err := cmd.Flags().GetString("workspace")
+			if err != nil {
+				return cmdError.NewCmdError(1, "must specify workspace id")
+			}
+			workspaceId = workspaceFlag
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
@@ -21,7 +31,7 @@ var addCmd = &cobra.Command{
 		if key == "" || value == "" || existsKey != nil || existsValue != nil {
 			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
 		}
-		err := exec.AddEnv(application, key, value)
+		err = exec.AddEnv(workspaceId, application, key, value)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -16,7 +16,7 @@ var addCmd = &cobra.Command{
 		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if err != nil {
+			if workspaceFlag != "" || err != nil {
 				return cmdError.NewCmdError(1, "must specify workspace id")
 			}
 			workspaceId = workspaceFlag

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -33,4 +33,5 @@ func init() {
 	envCmd.AddCommand(addCmd)
 	addCmd.Flags().StringP("key", "k", "", "environment key")
 	addCmd.Flags().StringP("value", "v", "", "environment value")
+	addCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
 	"github.com/spf13/cobra"
 )
 
@@ -12,11 +13,20 @@ var deployCmd = &cobra.Command{
 	Short: "command to deploy an application",
 	Long:  `this command is used to deploy an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId()
+		if err != nil {
+			workspaceFlag, err := cmd.Flags().GetString("workspace")
+			if err != nil {
+				return cmdError.NewCmdError(1, "must specify workspace id")
+			}
+			workspaceId = workspaceFlag
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
 		applicationId := args[0]
-		err := exec.DeployApplication(applicationId)
+		err = exec.DeployApplication(workspaceId, applicationId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -8,7 +8,7 @@ import (
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
-	Use:   "deploy <applicationId>",
+	Use:   "deploy <applicationId> [flags]",
 	Short: "command to deploy an application",
 	Long:  `this command is used to deploy an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -26,4 +26,6 @@ var deployCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
+
+	deployCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -16,7 +16,7 @@ var deployCmd = &cobra.Command{
 		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if err != nil {
+			if workspaceFlag != "" || err != nil {
 				return cmdError.NewCmdError(1, "must specify workspace id")
 			}
 			workspaceId = workspaceFlag

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -25,7 +25,7 @@ resourceType:
 
 		if resourceType == "applications" {
 			err, done := getApplication(cmd)
-			if done {
+			if !done {
 				return err
 			}
 		} else if resourceType == "workspaces" {
@@ -68,26 +68,27 @@ func getApplication(cmd *cobra.Command) (error, bool) {
 		}
 		workspaceId = workspaceFlag
 	}
+
 	applicationId, err := cmd.Flags().GetString("id")
-	if err != nil {
-		return err, false
+	if applicationId == "" || err != nil {
+		applications, err := exec.GetApplications(workspaceId)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error()), false
+		}
+
+		for _, application := range applications.Applications {
+			printApplication(application)
+		}
+
+		return nil, true
 	}
 
-	if applicationId == "" {
-		return cmdError.NewCmdError(1, "must specify application id"), false
-	}
-	if workspaceId == "" {
-		return cmdError.NewCmdError(1, "must specify workspace id"), false
-	}
-
-	applications, err := exec.GetApplications(workspaceId)
+	application, err := exec.GetApplication(workspaceId, applicationId)
 	if err != nil {
 		return cmdError.NewCmdError(1, err.Error()), false
 	}
 
-	for _, application := range applications.Applications {
-		printApplication(application)
-	}
+	printApplication(*application)
 
 	return nil, true
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -63,7 +63,7 @@ func getApplication(cmd *cobra.Command) (error, bool) {
 	workspaceId, err := util.GetWorkspaceId()
 	if err != nil {
 		workspaceFlag, err := cmd.Flags().GetString("workspace")
-		if err != nil {
+		if workspaceFlag != "" || err != nil {
 			return cmdError.NewCmdError(1, "must specify workspace id"), false
 		}
 		workspaceId = workspaceFlag

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,15 @@ var rmCmd = &cobra.Command{
 	Short: "use to delete an application's env",
 	Long:  `this command is used to delete an application's env`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId()
+		if err != nil {
+			workspaceFlag, err := cmd.Flags().GetString("workspace")
+			if err != nil {
+				return cmdError.NewCmdError(1, "must specify workspace id")
+			}
+			workspaceId = workspaceFlag
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
@@ -21,7 +31,7 @@ var rmCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, "should specify envKey")
 		}
 
-		err = exec.RemoveEnv(applicationId, envKey)
+		err = exec.RemoveEnv(workspaceId, applicationId, envKey)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -16,7 +16,7 @@ var rmCmd = &cobra.Command{
 		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if err != nil {
+			if workspaceFlag != "" || err != nil {
 				return cmdError.NewCmdError(1, "must specify workspace id")
 			}
 			workspaceId = workspaceFlag

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -34,4 +34,5 @@ func init() {
 	envCmd.AddCommand(rmCmd)
 
 	rmCmd.Flags().StringP("key", "", "", "select an key to delete")
+	rmCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,7 +17,7 @@ var runCmd = &cobra.Command{
 		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if err != nil {
+			if workspaceFlag != "" || err != nil {
 				return cmdError.NewCmdError(1, "must specify workspace id")
 			}
 			workspaceId = workspaceFlag

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
 
 	"github.com/spf13/cobra"
 )
@@ -13,11 +14,20 @@ var runCmd = &cobra.Command{
 	Short: "command to run an application",
 	Long:  `this command is used to run an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId()
+		if err != nil {
+			workspaceFlag, err := cmd.Flags().GetString("workspace")
+			if err != nil {
+				return cmdError.NewCmdError(1, "must specify workspace id")
+			}
+			workspaceId = workspaceFlag
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
 		applicationId := args[0]
-		err := exec.RunApplication(applicationId)
+		err = exec.RunApplication(workspaceId, applicationId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,4 +27,6 @@ var runCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(runCmd)
+
+	runCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
 
 	"github.com/spf13/cobra"
 )
@@ -13,11 +14,20 @@ var stopCmd = &cobra.Command{
 	Short: "command to stop an application",
 	Long:  `this command is used to stop an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId()
+		if err != nil {
+			workspaceFlag, err := cmd.Flags().GetString("workspace")
+			if err != nil {
+				return cmdError.NewCmdError(1, "must specify workspace id")
+			}
+			workspaceId = workspaceFlag
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
 		applicationId := args[0]
-		err := exec.StopApplication(applicationId)
+		err = exec.StopApplication(workspaceId, applicationId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -17,7 +17,7 @@ var stopCmd = &cobra.Command{
 		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if err != nil {
+			if workspaceFlag != "" || err != nil {
 				return cmdError.NewCmdError(1, "must specify workspace id")
 			}
 			workspaceId = workspaceFlag

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -27,4 +27,6 @@ var stopCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(stopCmd)
+
+	stopCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -17,7 +17,7 @@ var updateCmd = &cobra.Command{
 		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if err != nil {
+			if workspaceFlag != "" || err != nil {
 				return cmdError.NewCmdError(1, "must specify workspace id")
 			}
 			workspaceId = workspaceFlag

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
 
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,15 @@ var updateCmd = &cobra.Command{
 	Short: "use to update an application env",
 	Long:  `this command can be used to update a env to an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId()
+		if err != nil {
+			workspaceFlag, err := cmd.Flags().GetString("workspace")
+			if err != nil {
+				return cmdError.NewCmdError(1, "must specify workspace id")
+			}
+			workspaceId = workspaceFlag
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
@@ -22,7 +32,7 @@ var updateCmd = &cobra.Command{
 		if key == "" || value == "" || existsKey != nil || existsValue != nil {
 			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
 		}
-		err := exec.UpdateEnv(application, key, value)
+		err = exec.UpdateEnv(workspaceId, application, key, value)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,4 +35,5 @@ func init() {
 
 	updateCmd.Flags().StringP("key", "k", "", "environment key")
 	updateCmd.Flags().StringP("value", "v", "", "environment value")
+	updateCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/util/get_workspace_info.go
+++ b/cmd/util/get_workspace_info.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"encoding/json"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"os"
+)
+
+func GetWorkspaceId() (string, error) {
+	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
+	if err != nil {
+		return "", cmdError.NewCmdError(125, "not found workspace info")
+	}
+
+	var simpleWorkspaceInfo SimpleWorkspaceInfo
+
+	err = json.Unmarshal(rawWorkspaceInfo, &simpleWorkspaceInfo)
+	if err != nil {
+		return "", cmdError.NewCmdError(125, "invalid workspace info")
+	}
+
+	return simpleWorkspaceInfo.WorkspaceId, nil
+}

--- a/cmd/util/save_workspace_info.go
+++ b/cmd/util/save_workspace_info.go
@@ -7,10 +7,6 @@ import (
 	"os"
 )
 
-type SimpleWorkspaceInfo struct {
-	WorkspaceId string `json:"workspaceId"`
-}
-
 func SaveWorkspaceInfo(workspaceInfo exec.WorkspaceResponse) error {
 	simpleWorkspaceInfo := SimpleWorkspaceInfo{WorkspaceId: workspaceInfo.Id}
 

--- a/cmd/util/simple_workspace_info.go
+++ b/cmd/util/simple_workspace_info.go
@@ -1,0 +1,5 @@
+package util
+
+type SimpleWorkspaceInfo struct {
+	WorkspaceId string `json:"workspaceId"`
+}


### PR DESCRIPTION
## 개요
* dcd에서 애플리케이션에 접근할때 workspaceId를 사용하게끔 변경됨에 따라 cli에서 변경된 API 스펙에 맞춰서 수정
## 작업내용
* workspace info 구조체를 다른 파일로 분리
* GetWorksapceId 메서드 추가
* WorkspaceId 타입을 문자열로 수정
* 애플리케이션 접근 관련 커맨드에 worksapce(w) 플래그 추가
* API 호출 엔드포인트 변경
* GetApplication 메서드에서 workspaceId를 사용하게 수정
* command에서 workspaceId를 가져오는 로직 추가
* get 커맨드 분기(다수의 애플리케이션인지, 단일 애플리케이션인지) 로직 수정
* workspaceId가 플래그로 들어왔는지 검증하는 조건식 수정