### PR TITLE
🔀 :: [#62] - workspace id 조회 메서드 수정

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -13,13 +13,9 @@ var addCmd = &cobra.Command{
 	Short: "use to add an application env",
 	Long:  `this command can be used to add a env to an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspaceId, err := util.GetWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if workspaceFlag != "" || err != nil {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-			workspaceId = workspaceFlag
+			return err
 		}
 
 		if len(args) == 0 {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -32,13 +32,9 @@ var deleteCmd = &cobra.Command{
 				return cmdError.NewCmdError(1, err.Error())
 			}
 		} else if resourceType == "application" {
-			workspaceId, err := util.GetWorkspaceId()
+			workspaceId, err := util.GetWorkspaceId(cmd)
 			if err != nil {
-				workspaceFlag, err := cmd.Flags().GetString("workspace")
-				if workspaceFlag != "" || err != nil {
-					return cmdError.NewCmdError(1, "must specify workspace id")
-				}
-				workspaceId = workspaceFlag
+				return err
 			}
 
 			if args[1] == "" {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -13,13 +13,9 @@ var deployCmd = &cobra.Command{
 	Short: "command to deploy an application",
 	Long:  `this command is used to deploy an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspaceId, err := util.GetWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if workspaceFlag != "" || err != nil {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-			workspaceId = workspaceFlag
+			return err
 		}
 
 		if len(args) == 0 {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -60,13 +60,9 @@ func getWorkspace(cmd *cobra.Command) error {
 }
 
 func getApplication(cmd *cobra.Command) (error, bool) {
-	workspaceId, err := util.GetWorkspaceId()
+	workspaceId, err := util.GetWorkspaceId(cmd)
 	if err != nil {
-		workspaceFlag, err := cmd.Flags().GetString("workspace")
-		if workspaceFlag != "" || err != nil {
-			return cmdError.NewCmdError(1, "must specify workspace id"), false
-		}
-		workspaceId = workspaceFlag
+		return err, false
 	}
 
 	applicationId, err := cmd.Flags().GetString("id")

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -15,13 +15,9 @@ var logsCmd = &cobra.Command{
 	Short: "command to get application logs",
 	Long:  `this command is used to get application logs`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspaceId, err := util.GetWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if workspaceFlag != "" || err != nil {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-			workspaceId = workspaceFlag
+			return err
 		}
 
 		if len(args) == 0 || args[0] == "" {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -13,13 +13,9 @@ var rmCmd = &cobra.Command{
 	Short: "use to delete an application's env",
 	Long:  `this command is used to delete an application's env`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspaceId, err := util.GetWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if workspaceFlag != "" || err != nil {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-			workspaceId = workspaceFlag
+			return err
 		}
 
 		if len(args) == 0 {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,13 +14,9 @@ var runCmd = &cobra.Command{
 	Short: "command to run an application",
 	Long:  `this command is used to run an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspaceId, err := util.GetWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if workspaceFlag != "" || err != nil {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-			workspaceId = workspaceFlag
+			return err
 		}
 
 		if len(args) == 0 {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -14,13 +14,9 @@ var stopCmd = &cobra.Command{
 	Short: "command to stop an application",
 	Long:  `this command is used to stop an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspaceId, err := util.GetWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if workspaceFlag != "" || err != nil {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-			workspaceId = workspaceFlag
+			return err
 		}
 
 		if len(args) == 0 {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -14,13 +14,9 @@ var updateCmd = &cobra.Command{
 	Short: "use to update an application env",
 	Long:  `this command can be used to update a env to an application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspaceId, err := util.GetWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			workspaceFlag, err := cmd.Flags().GetString("workspace")
-			if workspaceFlag != "" || err != nil {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-			workspaceId = workspaceFlag
+			return err
 		}
 
 		if len(args) == 0 {

--- a/cmd/util/get_workspace_info.go
+++ b/cmd/util/get_workspace_info.go
@@ -2,21 +2,35 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/spf13/cobra"
 	"os"
 )
 
-func GetWorkspaceId() (string, error) {
+func GetWorkspaceId(cmd *cobra.Command) (string, error) {
+	workspaceId, err := getWorkspaceInfo()
+	if err != nil {
+		workspaceFlag, err := cmd.Flags().GetString("workspace")
+		if workspaceFlag != "" || err != nil {
+			return "", cmdError.NewCmdError(1, "must specify workspace id")
+		}
+		workspaceId = workspaceFlag
+	}
+	return workspaceId, nil
+}
+
+func getWorkspaceInfo() (string, error) {
 	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
 	if err != nil {
-		return "", cmdError.NewCmdError(125, "not found workspace info")
+		return "", errors.New("not found workspace info")
 	}
 
 	var simpleWorkspaceInfo SimpleWorkspaceInfo
 
 	err = json.Unmarshal(rawWorkspaceInfo, &simpleWorkspaceInfo)
 	if err != nil {
-		return "", cmdError.NewCmdError(125, "invalid workspace info")
+		return "", errors.New("invalid workspace info")
 	}
 
 	return simpleWorkspaceInfo.WorkspaceId, nil


### PR DESCRIPTION
## 개요
* workspace-info에서 workspace 정보를 못가져올때 커맨드의 플래그도 검사해서 가져오도록 수정합니다.
## 작업내용
* workspaceInfo 혹은 플래그에서 workspaceId를 가져오는 메서드 추가
* 커맨드에 변경된 GetWorkspaceId 적용