### PR TITLE
🔀 :: [#64] - 커맨드의 인수에는 빈 문자열이 들어갈 수 없음

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,7 +14,7 @@ var deleteCmd = &cobra.Command{
 	Long:  `this command will delete an resource.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return cmdError.NewCmdError(1, "must enter resource type and resource id")
+			return cmdError.NewCmdError(1, "must enter both resource type and resource id")
 		}
 
 		resourceType := args[0]

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -16,16 +16,9 @@ var deleteCmd = &cobra.Command{
 		if len(args) < 2 {
 			return cmdError.NewCmdError(1, "must enter resource type and resource id")
 		}
-		if args[0] == "" {
-			return cmdError.NewCmdError(1, "must specify a resource type")
-		}
 
 		resourceType := args[0]
 		if resourceType == "workspace" {
-			if args[1] == "" {
-				return cmdError.NewCmdError(1, "must specify workspace id")
-			}
-
 			var workspaceId = args[1]
 			err := exec.DeleteWorkspace(workspaceId)
 			if err != nil {
@@ -35,10 +28,6 @@ var deleteCmd = &cobra.Command{
 			workspaceId, err := util.GetWorkspaceId(cmd)
 			if err != nil {
 				return err
-			}
-
-			if args[1] == "" {
-				return cmdError.NewCmdError(1, "must specify application id")
 			}
 
 			var applicationId = args[1]

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -20,7 +20,7 @@ var logsCmd = &cobra.Command{
 			return err
 		}
 
-		if len(args) == 0 || args[0] == "" {
+		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
 		applicationId := args[0]


### PR DESCRIPTION
## 개요
* 커맨드의 인수에는 빈 문자열이 들어갈 수 없으므로, 굳이 인수가 빈 문자열인지 비교할 필요가 없음
## 작업내용
* logs 커맨드에서 인수가 빈 문자열인지 비교하는 조건 제거
* delete 커맨드에서 인수가 빈 문자열인지 비교하는 조건 제거
* delete 커맨드의 에러 문구 수정