### PR TITLE
🔀 :: [#66] - 데이터 출력 라이브러리 적용

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -57,7 +57,7 @@ func getWorkspace(cmd *cobra.Command) error {
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
-		fmt.Printf("ID: %s\nTitle: %s\nDescription: %s\n\n", workspace.Id, workspace.Title, workspace.Description)
+		printWorkspace(*workspace)
 	}
 	return nil
 }
@@ -135,6 +135,20 @@ func printApplicationList(applicationList []exec.ApplicationResponse) {
 		row := []string{application.Id, application.Name, application.Description, application.ApplicationType, application.GithubUrl, strconv.Itoa(application.Port), strconv.Itoa(application.ExternalPort), application.Version, application.Status}
 		table.Append(row)
 	}
+
+	table.Render()
+}
+
+func printWorkspace(workspace exec.WorkspaceResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+
+	id := []string{"ID", workspace.Id}
+	title := []string{"Name", workspace.Title}
+	description := []string{"Description", workspace.Description}
+
+	table.Append(id)
+	table.Append(title)
+	table.Append(description)
 
 	table.Render()
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -26,8 +26,8 @@ resourceType:
 		resourceType := args[0]
 
 		if resourceType == "applications" {
-			err, done := getApplication(cmd)
-			if !done {
+			err := getApplication(cmd)
+			if err != nil {
 				return err
 			}
 		} else if resourceType == "workspaces" {
@@ -64,32 +64,32 @@ func getWorkspace(cmd *cobra.Command) error {
 	return nil
 }
 
-func getApplication(cmd *cobra.Command) (error, bool) {
+func getApplication(cmd *cobra.Command) error {
 	workspaceId, err := util.GetWorkspaceId(cmd)
 	if err != nil {
-		return err, false
+		return err
 	}
 
 	applicationId, err := cmd.Flags().GetString("id")
 	if applicationId == "" || err != nil {
 		applications, err := exec.GetApplications(workspaceId)
 		if err != nil {
-			return cmdError.NewCmdError(1, err.Error()), false
+			return cmdError.NewCmdError(1, err.Error())
 		}
 
 		printApplicationList(applications.Applications)
 
-		return nil, true
+		return nil
 	}
 
 	application, err := exec.GetApplication(workspaceId, applicationId)
 	if err != nil {
-		return cmdError.NewCmdError(1, err.Error()), false
+		return cmdError.NewCmdError(1, err.Error())
 	}
 
 	printApplication(*application)
 
-	return nil, true
+	return nil
 }
 
 func init() {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -5,7 +5,10 @@ import (
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/dolong2/dcd-cli/cmd/util"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"os"
+	"strconv"
 )
 
 // getCmd represents the get command
@@ -113,4 +116,16 @@ func printApplication(application exec.ApplicationResponse) {
 	fmt.Printf("Status: %s\n", application.Status)
 	fmt.Println()
 	fmt.Println()
+}
+
+func printApplicationList(applicationList []exec.ApplicationResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ID", "Name", "Description", "Application Type", "Github URL", "Port", "External Port", "Version", "Status"})
+
+	for _, application := range applicationList {
+		row := []string{application.Id, application.Name, application.Description, application.ApplicationType, application.GithubUrl, strconv.Itoa(application.Port), strconv.Itoa(application.ExternalPort), application.Version, application.Status}
+		table.Append(row)
+	}
+
+	table.Render()
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/dolong2/dcd-cli/cmd/util"
@@ -49,16 +48,19 @@ func getWorkspace(cmd *cobra.Command) error {
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
-		for _, workspace := range workspaceList.List {
-			fmt.Printf("ID: %s\nTitle: %s\nDescription: %s\n\n", workspace.Id, workspace.Title, workspace.Description)
-		}
-	} else {
-		workspace, err := exec.GetWorkspace(id)
-		if err != nil {
-			return cmdError.NewCmdError(1, err.Error())
-		}
-		printWorkspace(*workspace)
+
+		printWorkspaceList(workspaceList.List)
+
+		return nil
 	}
+
+	workspace, err := exec.GetWorkspace(id)
+	if err != nil {
+		return cmdError.NewCmdError(1, err.Error())
+	}
+
+	printWorkspace(*workspace)
+
 	return nil
 }
 
@@ -149,6 +151,18 @@ func printWorkspace(workspace exec.WorkspaceResponse) {
 	table.Append(id)
 	table.Append(title)
 	table.Append(description)
+
+	table.Render()
+}
+
+func printWorkspaceList(workspaceList []exec.WorkspaceResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ID", "TITLE", "Description"})
+
+	for _, application := range workspaceList {
+		row := []string{application.Id, application.Title, application.Description}
+		table.Append(row)
+	}
 
 	table.Render()
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -75,9 +75,7 @@ func getApplication(cmd *cobra.Command) (error, bool) {
 			return cmdError.NewCmdError(1, err.Error()), false
 		}
 
-		for _, application := range applications.Applications {
-			printApplication(application)
-		}
+		printApplicationList(applications.Applications)
 
 		return nil, true
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -98,22 +98,33 @@ func init() {
 }
 
 func printApplication(application exec.ApplicationResponse) {
-	fmt.Printf("ID: %s\n", application.Id)
-	fmt.Printf("Name: %s\n", application.Name)
-	fmt.Printf("Description: %s\n", application.Description)
-	fmt.Printf("Application Type: %s\n", application.ApplicationType)
-	fmt.Printf("GitHub URL: %s\n", application.GithubUrl)
-	fmt.Printf("Environment Variables: [\n")
+	table := tablewriter.NewWriter(os.Stdout)
+
+	id := []string{"ID", application.Id}
+	name := []string{"Name", application.Name}
+	description := []string{"Description", application.Description}
+	applicationType := []string{"Application Type", application.ApplicationType}
+	githubUrl := []string{"GitHub Url", application.GithubUrl}
+	port := []string{"Port", strconv.Itoa(application.Port)}
+	externalPort := []string{"External Port", strconv.Itoa(application.ExternalPort)}
+	version := []string{"Version", application.Version}
+	status := []string{"Status", application.Status}
+
+	table.Append(id)
+	table.Append(name)
+	table.Append(description)
+	table.Append(applicationType)
+	table.Append(githubUrl)
 	for key, value := range application.Env {
-		fmt.Printf("  %s: %s\n", key, value)
+		env := []string{"ENV", key + " : " + value}
+		table.Append(env)
 	}
-	fmt.Printf("]\n")
-	fmt.Printf("Port: %d\n", application.Port)
-	fmt.Printf("External Port: %d\n", application.ExternalPort)
-	fmt.Printf("Version: %s\n", application.Version)
-	fmt.Printf("Status: %s\n", application.Status)
-	fmt.Println()
-	fmt.Println()
+	table.Append(port)
+	table.Append(externalPort)
+	table.Append(version)
+	table.Append(status)
+
+	table.Render()
 }
 
 func printApplicationList(applicationList []exec.ApplicationResponse) {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=


### PR DESCRIPTION
## 개요
* 애플리케이션, 워크스페이스 조회시 라이브러리를 적용해서 출력 포맷의 가독성을 높입니다.
## 작업내용
* tablewriter 라이브러리 추가
* printApplicationList 메서드 추가
* applicationList를 출력할때 printApplicationList 메서드를 호출하도록 변경
* printApplication 메서드에서 tablewriter를 사용하도록 수정
* printWorkspace 메서드 추가
* printWorkspacceList 메서드 추가
* getWorkspace 메서드 수정
* getApplication 메서드의 반환값 수정