### PR TITLE
🔀 :: [#78] - 전역 환경변수 추가 커맨드 작성

### DIFF
--- a/api/exec/add_global_env.go
+++ b/api/exec/add_global_env.go
@@ -1,0 +1,27 @@
+package exec
+
+import (
+	"encoding/json"
+	"github.com/dolong2/dcd-cli/api"
+)
+
+func addGlobalEnv(workspaceId string, key string, value string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	body := map[string]string{}
+	body[key] = value
+	envReq := envRequest{EnvList: body}
+	requestJson, err := json.Marshal(envReq)
+
+	_, err = api.SendPost("/workspace/"+workspaceId+"/env", header, requestJson)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -35,9 +35,45 @@ var addCmd = &cobra.Command{
 	},
 }
 
+// globalAddCmd represents the add command
+var globalAddCmd = &cobra.Command{
+	Use:   "add <workspaceId> [flags]",
+	Short: "use to add a global env",
+	Long:  `this command can be used to add a global env to an application.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId := ""
+
+		if len(args) == 0 {
+			var err error = nil
+			workspaceId, err = util.GetWorkspaceId(cmd)
+			if err != nil {
+				return err
+			}
+		} else {
+			workspaceId = args[0]
+		}
+
+		application := args[0]
+		key, existsKey := cmd.Flags().GetString("key")
+		value, existsValue := cmd.Flags().GetString("value")
+		if key == "" || value == "" || existsKey != nil || existsValue != nil {
+			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
+		}
+		err := exec.AddEnv(workspaceId, application, key, value)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+		return nil
+	},
+}
+
 func init() {
 	envCmd.AddCommand(addCmd)
 	addCmd.Flags().StringP("key", "k", "", "environment key")
 	addCmd.Flags().StringP("value", "v", "", "environment value")
 	addCmd.Flags().StringP("workspace", "w", "", "workspace id")
+	globalEnvCmd.AddCommand(globalAddCmd)
+	globalAddCmd.Flags().StringP("key", "k", "", "environment key")
+	globalAddCmd.Flags().StringP("value", "v", "", "environment value")
+	globalAddCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/globalEnv.go
+++ b/cmd/globalEnv.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// globalEnvCmd represents the globalEnv command
+var globalEnvCmd = &cobra.Command{
+	Use:   "global-env",
+	Short: "manage workspace global environment variables",
+	Long:  `command to manage global env`,
+	Run: func(cmd *cobra.Command, args []string) {
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(globalEnvCmd)
+}


### PR DESCRIPTION
## 개요
* 전역환 경변수를 추가할 수 있는 커맨드를 추가합니다.
## 작업내용
* globalEnv 커맨드 추가
* globalEnv 커맨드 하위에 add 커맨드 추가
* 전역 환경변수 추가 API를 호출하는 메서드 추가