### PR TITLE
🔀 :: [#80] - 전역 환경변수 삭제 커맨드 추가

### DIFF
--- a/api/exec/remove_global_env.go
+++ b/api/exec/remove_global_env.go
@@ -1,0 +1,22 @@
+package exec
+
+import "github.com/dolong2/dcd-cli/api"
+
+func RemoveGlobalEnv(workspaceId string, envKey string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	params := make(map[string]string)
+	params["key"] = envKey
+
+	_, err = api.SendDelete("/workspace/"+workspaceId+"/env", header, params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -75,5 +75,4 @@ func init() {
 	globalEnvCmd.AddCommand(globalAddCmd)
 	globalAddCmd.Flags().StringP("key", "k", "", "environment key")
 	globalAddCmd.Flags().StringP("value", "v", "", "environment value")
-	globalAddCmd.Flags().StringP("workspace", "w", "", "workspace id")
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -35,8 +35,8 @@ var addCmd = &cobra.Command{
 	},
 }
 
-// globalAddCmd represents the add command
-var globalAddCmd = &cobra.Command{
+// addGlobalEnvCmd represents the add command
+var addGlobalEnvCmd = &cobra.Command{
 	Use:   "add <workspaceId> [flags]",
 	Short: "use to add a global env",
 	Long:  `this command can be used to add a global env to an application.`,
@@ -72,7 +72,7 @@ func init() {
 	addCmd.Flags().StringP("key", "k", "", "environment key")
 	addCmd.Flags().StringP("value", "v", "", "environment value")
 	addCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	globalEnvCmd.AddCommand(globalAddCmd)
-	globalAddCmd.Flags().StringP("key", "k", "", "environment key")
-	globalAddCmd.Flags().StringP("value", "v", "", "environment value")
+	globalEnvCmd.AddCommand(addGlobalEnvCmd)
+	addGlobalEnvCmd.Flags().StringP("key", "k", "", "environment key")
+	addGlobalEnvCmd.Flags().StringP("value", "v", "", "environment value")
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -36,9 +36,44 @@ var rmCmd = &cobra.Command{
 	},
 }
 
+// rmGlobalEnvCmd represents the rm command under global-env
+var rmGlobalEnvCmd = &cobra.Command{
+	Use:   "rm <workspaceId> [flags]",
+	Short: "use to delete an application's env",
+	Long:  `this command is used to delete an application's env`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId := ""
+
+		if len(args) == 0 {
+			var err error = nil
+			workspaceId, err = util.GetWorkspaceId(cmd)
+			if err != nil {
+				return err
+			}
+		} else {
+			workspaceId = args[0]
+		}
+
+		envKey, err := cmd.Flags().GetString("key")
+		if err != nil || envKey == "" {
+			return cmdError.NewCmdError(1, "should specify envKey")
+		}
+
+		err = exec.RemoveGlobalEnv(workspaceId, envKey)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		return nil
+	},
+}
+
 func init() {
 	envCmd.AddCommand(rmCmd)
 
-	rmCmd.Flags().StringP("key", "", "", "select an key to delete")
+	rmCmd.Flags().StringP("key", "", "", "select a key to delete")
 	rmCmd.Flags().StringP("workspace", "w", "", "workspace id")
+
+	globalEnvCmd.AddCommand(rmGlobalEnvCmd)
+	rmGlobalEnvCmd.Flags().StringP("key", "", "", "select a key to delete")
 }


### PR DESCRIPTION
## 개요
* 전역 환경변수를 삭제하는 커맨드를 추가합니다.
## 작업내용
* globalAdd 커맨드의 workspace 플래그 제거
* globalAdd 커맨드의 변수 네이밍 수정
* removeGlobalEnv 메서드 추가
* global-env 커맨드 하위에 rm 커맨드 추가