### PR TITLE
🔀 :: [#84] - 워크스페이스 조회 커맨드 수정

### DIFF
--- a/api/exec/get_workspace.go
+++ b/api/exec/get_workspace.go
@@ -15,6 +15,13 @@ type WorkspaceResponse struct {
 	Description string `json:"description"`
 }
 
+type WorkspaceDetailResponse struct {
+	Id          string            `json:"id"`
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	GlobalEnv   map[string]string `json:"globalEnv"`
+}
+
 func GetWorkspaces() (*WorkspaceListResponse, error) {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
@@ -37,7 +44,7 @@ func GetWorkspaces() (*WorkspaceListResponse, error) {
 	return &workspaceListResponse, nil
 }
 
-func GetWorkspace(id string) (*WorkspaceResponse, error) {
+func GetWorkspace(id string) (*WorkspaceDetailResponse, error) {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -50,7 +57,7 @@ func GetWorkspace(id string) (*WorkspaceResponse, error) {
 		return nil, err
 	}
 
-	var workspaceResponse WorkspaceResponse
+	var workspaceResponse WorkspaceDetailResponse
 	err = json.Unmarshal(response, &workspaceResponse)
 	if err != nil {
 		return nil, err

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // getCmd represents the get command
@@ -146,16 +147,23 @@ func printApplicationList(applicationList []exec.ApplicationResponse) {
 	table.Render()
 }
 
-func printWorkspace(workspace exec.WorkspaceResponse) {
+func printWorkspace(workspace exec.WorkspaceDetailResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
 
 	id := []string{"ID", workspace.Id}
 	title := []string{"Name", workspace.Title}
 	description := []string{"Description", workspace.Description}
+	envString := ""
+	for key, value := range workspace.GlobalEnv {
+		envString += "{ " + key + " : " + value + " } , "
+	}
+	envString = envString[:len(envString)-1]
+	globalEnv := []string{"Global Env", strings.Trim(envString, ",")}
 
 	table.Append(id)
 	table.Append(title)
 	table.Append(description)
+	table.Append(globalEnv)
 
 	table.Render()
 }

--- a/cmd/util/save_workspace_info.go
+++ b/cmd/util/save_workspace_info.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-func SaveWorkspaceInfo(workspaceInfo exec.WorkspaceResponse) error {
+func SaveWorkspaceInfo(workspaceInfo exec.WorkspaceDetailResponse) error {
 	simpleWorkspaceInfo := SimpleWorkspaceInfo{WorkspaceId: workspaceInfo.Id}
 
 	rawResult, err := json.Marshal(simpleWorkspaceInfo)


### PR DESCRIPTION
## 개요
* 워크스페이스 단일 조회 커맨드에서 전역 환경변수를 수정합니다.
## 작업내용
* getWorkspace 메서드에 WorkspaceDetailResponse 추가
* SaveWorksacpeInfo 메서드 수정
* workspace 단일 조회시 전역 환경변수도 조회되도록 수정