### PR TITLE
🔀 :: [#98] - use로 설정한 워크스페이스보다 워크스페이스 플래그가 우선순위가 더 높도록 수정

### DIFF
--- a/cmd/util/get_workspace_info.go
+++ b/cmd/util/get_workspace_info.go
@@ -9,13 +9,12 @@ import (
 )
 
 func GetWorkspaceId(cmd *cobra.Command) (string, error) {
-	workspaceId, err := getWorkspaceInfo()
-	if err != nil {
-		workspaceFlag, err := cmd.Flags().GetString("workspace")
-		if workspaceFlag != "" || err != nil {
+	workspaceId, err := cmd.Flags().GetString("workspace")
+	if err != nil || workspaceId == "" {
+		workspaceId, err = getWorkspaceInfo()
+		if err != nil {
 			return "", cmdError.NewCmdError(1, "must specify workspace id")
 		}
-		workspaceId = workspaceFlag
 	}
 	return workspaceId, nil
 }


### PR DESCRIPTION
## 개요
* use로 설정한 워크스페이스보다 워크스페이스 플래그로 설정한 워크스페이스가 우선순위가 더 높도록 수정
## 작업내용
* 워크스페이스 정보를 가져올때 커맨드의 workspace 플래그의 우선순위가 더 높도록 수정