### PR TITLE
🔀 :: [#105] - 애플리케이션 생성시 템플릿에 workspaceId를 적지 않아도 되게 수정

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -31,7 +31,6 @@ type workspaceRequest struct {
 
 type applicationTemplate struct {
 	Metadata        metaData          `json:"metadata" yaml:"metadata"`
-	WorkspaceId     string            `json:"workspaceId" yaml:"workspaceId"`
 	GithubUrl       string            `json:"githubUrl" yaml:"githubUrl"`
 	Env             map[string]string `json:"env" yaml:"env"`
 	ApplicationType string            `json:"applicationType" yaml:"applicationType"`
@@ -133,7 +132,13 @@ func createByJson(content []byte) error {
 		if err != nil {
 			return err
 		}
-		_, err = api.SendPost("/"+application.WorkspaceId+"/application", header, map[string]string{}, request)
+
+		workspaceId, err := getWorkspaceId()
+		if err != nil {
+			return err
+		}
+
+		_, err = api.SendPost("/"+workspaceId+"/application", header, map[string]string{}, request)
 		if err != nil {
 			return err
 		}
@@ -195,7 +200,12 @@ func createByYml(content []byte) error {
 			return err
 		}
 
-		_, err = api.SendPost("/"+application.WorkspaceId+"/application", header, map[string]string{}, request)
+		workspaceId, err := getWorkspaceId()
+		if err != nil {
+			return err
+		}
+
+		_, err = api.SendPost("/"+workspaceId+"/application", header, map[string]string{}, request)
 		if err != nil {
 			return err
 		}

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -61,7 +61,7 @@ getTokenInfo:
 	return tokenInfo.AccessToken, nil
 }
 
-func GetWorkspaceId() (string, error) {
+func getWorkspaceId() (string, error) {
 	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
 	if err != nil {
 		return "", errors.New("not found workspace info")

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -60,3 +60,21 @@ getTokenInfo:
 	}
 	return tokenInfo.AccessToken, nil
 }
+
+func GetWorkspaceId() (string, error) {
+	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
+	if err != nil {
+		return "", errors.New("not found workspace info")
+	}
+
+	var workspaceInfo map[string]interface{}
+
+	err = json.Unmarshal(rawWorkspaceInfo, &workspaceInfo)
+	if err != nil {
+		return "", errors.New("invalid workspace info")
+	}
+
+	workspaceId := workspaceInfo["workspaceId"].(string)
+
+	return workspaceId, nil
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -38,6 +38,6 @@ var createCmd = &cobra.Command{
 
 func init() {
 	createCmd.Flags().StringP("file", "f", "", "file path where a resource format is defined")
-	createCmd.Flags().StringP("template", "", "", "resource template to json")
+	createCmd.Flags().StringP("template", "t", "", "resource template to json")
 	rootCmd.AddCommand(createCmd)
 }

--- a/example/json/application/test-application.json
+++ b/example/json/application/test-application.json
@@ -4,7 +4,6 @@
     "name": "test-application-with-json",
     "description": "application created by json"
   },
-  "workspaceId": "ca5690bb-6525-48aa-93a1-7a24dc0085b6",
   "githubUrl": "",
   "env": {
     "test":  "1234"

--- a/example/yml/application/test-application.yml
+++ b/example/yml/application/test-application.yml
@@ -2,7 +2,6 @@ metadata:
   resourceType: APPLICATION
   name: test-application-with-yml
   description: application created by yml
-workspaceId: 41fc5400-7a5a-4b1b-8a23-53c9c5627be0
 githubUrl: ''
 env:
   test: '1234'


### PR DESCRIPTION
## 개요
* 워크스페이스 id를 조회하는 메서드 추가
## 작업내용
* exec패키지에 워크스페이스 id를 조회하는 메서드 추가
* 애플리케이션 템플릿에서 workspaceId를 사용하지 않도록 수정
* create 명령의 template 플래그의 shorthand 추가
* 예제 템플릿에서 workspaceId를 사용하는 부분 제거