### PR TITLE
🔀 :: [#106] - 애플리케이션 get 커맨드에 label 플래그 추가

### DIFF
--- a/api/api_client.go
+++ b/api/api_client.go
@@ -63,7 +63,7 @@ func SendPut(targetUrl string, header map[string]string, param map[string]string
 }
 
 func sendHttpReq(method string, targetUrl string, header map[string]string, param map[string]string, body []byte) ([]byte, error) {
-	if len(param) == 0 {
+	if len(param) != 0 {
 		query := url.Values{}
 		for key, value := range param {
 			query.Add(key, value)

--- a/api/exec/get_application.go
+++ b/api/exec/get_application.go
@@ -45,6 +45,31 @@ func GetApplications(workspaceId string) (*ApplicationListResponse, error) {
 	return &applicationListResponse, nil
 }
 
+func GetApplicationsByLabels(workspaceId string, labels string) (*ApplicationListResponse, error) {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	param := make(map[string]string)
+	param["labels"] = labels
+
+	response, err := api.SendGet("/"+workspaceId+"/application", header, param)
+	if err != nil {
+		return nil, err
+	}
+
+	var applicationListResponse ApplicationListResponse
+	err = json.Unmarshal(response, &applicationListResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &applicationListResponse, nil
+}
+
 func GetApplication(workspaceId string, applicationId string) (*ApplicationResponse, error) {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -84,7 +84,7 @@ func getApplication(cmd *cobra.Command) error {
 		var applications *exec.ApplicationListResponse
 
 		// id, labels 플래그 둘다 없을때, 조건 없이 애플리케이션 조회
-		if labels == "" && err != nil {
+		if labels == "" && err == nil {
 			applications, err = exec.GetApplications(workspaceId)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -77,10 +77,27 @@ func getApplication(cmd *cobra.Command) error {
 	}
 
 	applicationId, err := cmd.Flags().GetString("id")
-	if applicationId == "" || err != nil {
-		applications, err := exec.GetApplications(workspaceId)
-		if err != nil {
-			return cmdError.NewCmdError(1, err.Error())
+
+	if applicationId == "" && err == nil {
+		labels, err := cmd.Flags().GetString("labels")
+
+		var applications *exec.ApplicationListResponse
+
+		// id, labels 플래그 둘다 없을때, 조건 없이 애플리케이션 조회
+		if labels == "" && err != nil {
+			applications, err = exec.GetApplications(workspaceId)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
+
+			printApplicationList(applications.Applications)
+
+			return nil
+		} else {
+			applications, err = exec.GetApplicationsByLabels(workspaceId, labels)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
 		}
 
 		printApplicationList(applications.Applications)
@@ -103,6 +120,7 @@ func init() {
 
 	getCmd.Flags().StringP("workspace", "w", "", "used to get resources in a workspace")
 	getCmd.Flags().StringP("id", "", "", "specify resource id")
+	getCmd.Flags().StringP("labels", "l", "", "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). test-label-1,test-label-2")
 }
 
 func printApplication(application exec.ApplicationResponse) {


### PR DESCRIPTION
## 개요
* 애플리케이션 get 커맨드에 label 플래그를 추가합니다.
## 작업내용
* http 요청을 보낼때 파라미터 검증 조건 수정
* label로 애플리케이션을 조회하는 메서드 추가
* get 커맨드에 label 플래그 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 애플리케이션을 특정 레이블로 검색할 수 있는 기능 추가.
	- 명령어에 레이블을 지정할 수 있는 새로운 플래그 추가.
- **버그 수정**
	- 애플리케이션 검색 로직 개선, 이제 ID와 레이블 플래그를 올바르게 처리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->