### PR TITLE
🔀 :: [#112] - 애플리케이션 라벨을 string 배열로 받도록 수정

### DIFF
--- a/api/exec/deploy.go
+++ b/api/exec/deploy.go
@@ -1,6 +1,9 @@
 package exec
 
-import "github.com/dolong2/dcd-cli/api"
+import (
+	"github.com/dolong2/dcd-cli/api"
+	"strings"
+)
 
 func DeployApplication(workspaceId string, applicationId string) error {
 	header := make(map[string]string)
@@ -14,7 +17,7 @@ func DeployApplication(workspaceId string, applicationId string) error {
 	return err
 }
 
-func DeployApplicationWithLabels(workspaceId string, labels string) error {
+func DeployApplicationWithLabels(workspaceId string, labels []string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -23,7 +26,7 @@ func DeployApplicationWithLabels(workspaceId string, labels string) error {
 	header["Authorization"] = "Bearer " + accessToken
 
 	params := make(map[string]string)
-	params["labels"] = labels
+	params["labels"] = strings.Join(labels, ",")
 	_, err = api.SendPost("/"+workspaceId+"/application/deploy", header, params, []byte(""))
 	return err
 }

--- a/api/exec/get_application.go
+++ b/api/exec/get_application.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"encoding/json"
 	"github.com/dolong2/dcd-cli/api"
+	"strings"
 )
 
 type ApplicationResponse struct {
@@ -45,7 +46,7 @@ func GetApplications(workspaceId string) (*ApplicationListResponse, error) {
 	return &applicationListResponse, nil
 }
 
-func GetApplicationsByLabels(workspaceId string, labels string) (*ApplicationListResponse, error) {
+func GetApplicationsByLabels(workspaceId string, labels []string) (*ApplicationListResponse, error) {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -54,7 +55,7 @@ func GetApplicationsByLabels(workspaceId string, labels string) (*ApplicationLis
 	header["Authorization"] = "Bearer " + accessToken
 
 	param := make(map[string]string)
-	param["labels"] = labels
+	param["labels"] = strings.Join(labels, ",")
 
 	response, err := api.SendGet("/"+workspaceId+"/application", header, param)
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -43,5 +43,5 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 
 	deployCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	deployCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). test-label-1,test-label-2")
+	deployCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -18,8 +18,8 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 
-		labels, err := cmd.Flags().GetString("labels")
-		if labels != "" && err == nil {
+		labels, err := cmd.Flags().GetStringArray("labels")
+		if len(labels) != 0 && err == nil {
 			err := exec.DeployApplicationWithLabels(workspaceId, labels)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
@@ -43,5 +43,5 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 
 	deployCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	deployCmd.Flags().StringP("labels", "l", "", "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). test-label-1,test-label-2")
+	deployCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). test-label-1,test-label-2")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -19,7 +19,10 @@ var deployCmd = &cobra.Command{
 		}
 
 		labels, err := cmd.Flags().GetStringArray("labels")
-		if len(labels) != 0 && err == nil {
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+		if len(labels) != 0 {
 			err := exec.DeployApplicationWithLabels(workspaceId, labels)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -79,12 +79,12 @@ func getApplication(cmd *cobra.Command) error {
 	applicationId, err := cmd.Flags().GetString("id")
 
 	if applicationId == "" && err == nil {
-		labels, err := cmd.Flags().GetString("labels")
+		labels, err := cmd.Flags().GetStringArray("labels")
 
 		var applications *exec.ApplicationListResponse
 
 		// id, labels 플래그 둘다 없을때, 조건 없이 애플리케이션 조회
-		if labels == "" || err != nil {
+		if len(labels) == 0 || err != nil {
 			applications, err = exec.GetApplications(workspaceId)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
@@ -120,7 +120,7 @@ func init() {
 
 	getCmd.Flags().StringP("workspace", "w", "", "used to get resources in a workspace")
 	getCmd.Flags().StringP("id", "", "", "specify resource id")
-	getCmd.Flags().StringP("labels", "l", "", "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). test-label-1,test-label-2")
+	getCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). test-label-1,test-label-2")
 }
 
 func printApplication(application exec.ApplicationResponse) {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -120,7 +120,7 @@ func init() {
 
 	getCmd.Flags().StringP("workspace", "w", "", "used to get resources in a workspace")
 	getCmd.Flags().StringP("id", "", "", "specify resource id")
-	getCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). test-label-1,test-label-2")
+	getCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }
 
 func printApplication(application exec.ApplicationResponse) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,7 +20,11 @@ var runCmd = &cobra.Command{
 		}
 
 		labels, err := cmd.Flags().GetStringArray("labels")
-		if len(labels) != 0 && err == nil {
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		if len(labels) != 0 {
 			err := exec.RunApplicationWithLabels(workspaceId, labels)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())


### PR DESCRIPTION
## 개요
* 라벨 플래그를 사용하는 부분에서 string 배열로 받도록 수정합니다.
## 작업내용
* labels 플래그를 StringArray로 수정
* DeployApplicationWithLabels 메서드에서 labels를 string 배열로 받도록 수정
* GetApplicationsByLabels 메서드에서 labels를 string 배열로 받도록 수정
* labels 플래그 설명 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 배포 및 검색 명령에서 여러 레이블을 지정할 수 있는 기능 추가.

- **버그 수정**
  - 레이블 처리 로직 개선으로 더 유연한 입력 가능.
  - 명령 플래그 검색 시 오류 처리 로직 개선.

- **문서화**
  - 레이블 플래그 사용법에 대한 문서 업데이트 및 예시 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->