### PR TITLE
🔀 :: [#114] - 애플리케이션 정지 커맨드에 label 플래그 추가

### DIFF
--- a/api/exec/stop.go
+++ b/api/exec/stop.go
@@ -1,6 +1,9 @@
 package exec
 
-import "github.com/dolong2/dcd-cli/api"
+import (
+	"github.com/dolong2/dcd-cli/api"
+	"strings"
+)
 
 func StopApplication(workspaceId string, applicationId string) error {
 	header := make(map[string]string)
@@ -11,5 +14,19 @@ func StopApplication(workspaceId string, applicationId string) error {
 	header["Authorization"] = "Bearer " + accessToken
 
 	_, err = api.SendPost("/"+workspaceId+"/application/"+applicationId+"/stop", header, map[string]string{}, []byte(""))
+	return err
+}
+
+func StopApplicationWithLabels(workspaceId string, labels []string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	params := make(map[string]string)
+	params["labels"] = strings.Join(labels, ",")
+	_, err = api.SendPost("/"+workspaceId+"/application/stop", header, params, []byte(""))
 	return err
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -46,5 +46,5 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 
 	deployCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	deployCmd.Flags().StringArrayP("label", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
+	deployCmd.Flags().StringArrayP("label", "l", []string{}, "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -18,7 +18,7 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 
-		labels, err := cmd.Flags().GetStringArray("labels")
+		labels, err := cmd.Flags().GetStringArray("label")
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
@@ -46,5 +46,5 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 
 	deployCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	deployCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
+	deployCmd.Flags().StringArrayP("label", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -79,7 +79,7 @@ func getApplication(cmd *cobra.Command) error {
 	applicationId, err := cmd.Flags().GetString("id")
 
 	if applicationId == "" && err == nil {
-		labels, err := cmd.Flags().GetStringArray("labels")
+		labels, err := cmd.Flags().GetStringArray("label")
 
 		var applications *exec.ApplicationListResponse
 
@@ -120,7 +120,7 @@ func init() {
 
 	getCmd.Flags().StringP("workspace", "w", "", "used to get resources in a workspace")
 	getCmd.Flags().StringP("id", "", "", "specify resource id")
-	getCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
+	getCmd.Flags().StringArrayP("label", "l", []string(nil), "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }
 
 func printApplication(application exec.ApplicationResponse) {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -120,7 +120,7 @@ func init() {
 
 	getCmd.Flags().StringP("workspace", "w", "", "used to get resources in a workspace")
 	getCmd.Flags().StringP("id", "", "", "specify resource id")
-	getCmd.Flags().StringArrayP("label", "l", []string(nil), "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
+	getCmd.Flags().StringArrayP("label", "l", []string{}, "select labels for applications.\nif use this flag when get workspaces, this flag will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }
 
 func printApplication(application exec.ApplicationResponse) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -48,5 +48,5 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	runCmd.Flags().StringArrayP("label", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
+	runCmd.Flags().StringArrayP("label", "l", []string{}, "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,7 +19,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		labels, err := cmd.Flags().GetStringArray("labels")
+		labels, err := cmd.Flags().GetStringArray("label")
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
@@ -48,5 +48,5 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	runCmd.Flags().StringArrayP("labels", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
+	runCmd.Flags().StringArrayP("label", "l", []string(nil), "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -35,4 +35,5 @@ func init() {
 	rootCmd.AddCommand(stopCmd)
 
 	stopCmd.Flags().StringP("workspace", "w", "", "workspace id")
+	stopCmd.Flags().StringArrayP("label", "l", []string{}, "select labels for applications.\nwhen use this flag if you enter application id, application id will be ignored.\nif used together with the Id flag, this flag will be ignored\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -19,6 +19,18 @@ var stopCmd = &cobra.Command{
 			return err
 		}
 
+		labels, err := cmd.Flags().GetStringArray("label")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+		if len(labels) != 0 {
+			err := exec.StopApplicationWithLabels(workspaceId, labels)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
+			return nil
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}


### PR DESCRIPTION
## 개요
* 애플리케이션 정지 커맨드에 label 플래그를 추가합니다.
## 작업내용
* labels 플래그를 label로 네이밍 수정
* labels 플래그의 value 수정
* 라벨로 애플리케이션 정지시키는 API를 호출하는 메서드 추가
* stop 커맨드에 label 플래그 추가
* 받은 label 커맨드로 애플리케이션을 정지하는 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 애플리케이션을 레이블을 기반으로 중지할 수 있는 기능 추가.
	- `--label` 플래그를 통해 여러 레이블을 지정하여 애플리케이션 중지 가능.

- **변경 사항**
	- `labels` 플래그가 `label`로 이름 변경.
	- `get`, `run`, `deploy` 명령어에서 플래그 변경 사항 반영. 

- **버그 수정**
	- 중지 명령어에서 레이블 처리 로직 개선 및 오류 처리 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->