### PR TITLE
🔀 :: [#116] - env 추가 커맨드에 labels 플래그 추가

### DIFF
--- a/api/exec/add_env.go
+++ b/api/exec/add_env.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"encoding/json"
 	"github.com/dolong2/dcd-cli/api"
+	"strings"
 )
 
 type envRequest struct {
@@ -23,6 +24,30 @@ func AddEnv(workspaceId string, applicationId string, key string, value string) 
 	requestJson, err := json.Marshal(envReq)
 
 	_, err = api.SendPost("/"+workspaceId+"/application/"+applicationId+"/env", header, map[string]string{}, requestJson)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func AddEnvWithLabels(workspaceId string, labels []string, key string, value string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	body := map[string]string{}
+	body[key] = value
+	envReq := envRequest{EnvList: body}
+	requestJson, err := json.Marshal(envReq)
+
+	params := make(map[string]string)
+	params["labels"] = strings.Join(labels, ",")
+
+	_, err = api.SendPost("/"+workspaceId+"/application/env", header, params, requestJson)
 	if err != nil {
 		return err
 	}

--- a/api/exec/add_env.go
+++ b/api/exec/add_env.go
@@ -23,6 +23,10 @@ func AddEnv(workspaceId string, applicationId string, key string, value string) 
 	envReq := envRequest{EnvList: body}
 	requestJson, err := json.Marshal(envReq)
 
+	if err != nil {
+		return err
+	}
+
 	_, err = api.SendPost("/"+workspaceId+"/application/"+applicationId+"/env", header, map[string]string{}, requestJson)
 	if err != nil {
 		return err
@@ -43,6 +47,10 @@ func AddEnvWithLabels(workspaceId string, labels []string, key string, value str
 	body[key] = value
 	envReq := envRequest{EnvList: body}
 	requestJson, err := json.Marshal(envReq)
+
+	if err != nil {
+		return err
+	}
 
 	params := make(map[string]string)
 	params["labels"] = strings.Join(labels, ",")

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -72,6 +72,7 @@ func init() {
 	addCmd.Flags().StringP("key", "k", "", "environment key")
 	addCmd.Flags().StringP("value", "v", "", "environment value")
 	addCmd.Flags().StringP("workspace", "w", "", "workspace id")
+	addCmd.Flags().StringArrayP("labels", "l", []string{}, "select labels for applications.\nif use this flag, you are no need to use application id.\nex). -l test-label-1 -l test-label-2")
 	globalEnvCmd.AddCommand(addGlobalEnvCmd)
 	addGlobalEnvCmd.Flags().StringP("key", "k", "", "environment key")
 	addGlobalEnvCmd.Flags().StringP("value", "v", "", "environment value")

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,6 +24,20 @@ var addCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
 		}
 
+		labels, err := cmd.Flags().GetStringArray("labels")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		// label을 하나라도 받았을때 애플리케이션 id를 사용하지 않고, 라벨로 환경변수를 추가
+		if len(labels) != 0 {
+			err := exec.AddEnvWithLabels(workspaceId, labels, key, value)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
+			return nil
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -18,15 +18,16 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
+		key, keyErr := cmd.Flags().GetString("key")
+		value, valueErr := cmd.Flags().GetString("value")
+		if key == "" || value == "" || keyErr != nil || valueErr != nil {
+			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
+		}
+
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "must specify applicationId")
 		}
 		application := args[0]
-		key, existsKey := cmd.Flags().GetString("key")
-		value, existsValue := cmd.Flags().GetString("value")
-		if key == "" || value == "" || existsKey != nil || existsValue != nil {
-			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
-		}
 		err = exec.AddEnv(workspaceId, application, key, value)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())


### PR DESCRIPTION
## 개요
* env 추가 커맨드에 labels 플래그를 추가합니다.
## 작업내용
* label을 받아서 해당 라벨이 포함된 애플리케이션에 환경변수를 추가하는 API 호출 메서드 추가
* labels 플래그 추가
* 환경변수의 key, value을 애플리케이션 id보다 먼저 가져오도록 수정
* label을 가져오는 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 환경 변수를 추가할 때 라벨을 함께 지정할 수 있는 기능 추가.
	- 명령어에 `labels` 플래그 추가, 여러 라벨을 지정할 수 있도록 지원.

- **버그 수정**
	- 명령어 실행 시 `key`와 `value` 플래그의 오류 처리 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->