### PR TITLE
🔀 :: [#118] - env 삭제 커맨드에 label 플래그 추가

### DIFF
--- a/api/exec/remove_env.go
+++ b/api/exec/remove_env.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"github.com/dolong2/dcd-cli/api"
+	"strings"
 )
 
 func RemoveEnv(workspaceId string, applicationId string, envKey string) error {
@@ -16,6 +17,26 @@ func RemoveEnv(workspaceId string, applicationId string, envKey string) error {
 	params["key"] = envKey
 
 	_, err = api.SendDelete("/"+workspaceId+"/application/"+applicationId+"/env", header, params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RemoveEnvWithLabels(workspaceId string, labels []string, envKey string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	params := make(map[string]string)
+	params["key"] = envKey
+	params["labels"] = strings.Join(labels, ",")
+
+	_, err = api.SendDelete("/"+workspaceId+"/application/env", header, params)
 	if err != nil {
 		return err
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,7 +24,7 @@ var addCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
 		}
 
-		labels, err := cmd.Flags().GetStringArray("labels")
+		labels, err := cmd.Flags().GetStringArray("label")
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
@@ -87,7 +87,7 @@ func init() {
 	addCmd.Flags().StringP("key", "k", "", "environment key")
 	addCmd.Flags().StringP("value", "v", "", "environment value")
 	addCmd.Flags().StringP("workspace", "w", "", "workspace id")
-	addCmd.Flags().StringArrayP("labels", "l", []string{}, "select labels for applications.\nif use this flag, you are no need to use application id.\nex). -l test-label-1 -l test-label-2")
+	addCmd.Flags().StringArrayP("label", "l", []string{}, "select labels for applications.\nif use this flag, you are no need to use application id.\nex). -l test-label-1 -l test-label-2")
 	globalEnvCmd.AddCommand(addGlobalEnvCmd)
 	addGlobalEnvCmd.Flags().StringP("key", "k", "", "environment key")
 	addGlobalEnvCmd.Flags().StringP("value", "v", "", "environment value")

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -18,14 +18,28 @@ var rmCmd = &cobra.Command{
 			return err
 		}
 
-		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
-		}
-		applicationId := args[0]
 		envKey, err := cmd.Flags().GetString("key")
 		if err != nil || envKey == "" {
 			return cmdError.NewCmdError(1, "should specify envKey")
 		}
+
+		labels, err := cmd.Flags().GetStringArray("label")
+		if err != nil {
+			return err
+		}
+
+		if len(labels) != 0 {
+			err := exec.RemoveEnvWithLabels(workspaceId, labels, envKey)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if len(args) == 0 {
+			return cmdError.NewCmdError(1, "must specify applicationId")
+		}
+		applicationId := args[0]
 
 		err = exec.RemoveEnv(workspaceId, applicationId, envKey)
 		if err != nil {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -73,6 +73,7 @@ func init() {
 
 	rmCmd.Flags().StringP("key", "", "", "select a key to delete")
 	rmCmd.Flags().StringP("workspace", "w", "", "workspace id")
+	rmCmd.Flags().StringArrayP("label", "l", []string{}, "select labels for applications.\nif use this flag, you are no need to use application id.\nex). -l test-label-1 -l test-label-2")
 
 	globalEnvCmd.AddCommand(rmGlobalEnvCmd)
 	rmGlobalEnvCmd.Flags().StringP("key", "", "", "select a key to delete")


### PR DESCRIPTION
## 개요
* env 삭제 커맨드에 label 플래그를 추가합니다.
## 작업내용
* env add 커맨드의 labels 플래그의 네이밍을 label로 수정
* 환경변수를 라벨로 삭제하는 API를 호출하는 메서드 추가
* env rm 커맨드에 label 플래그 추가
* env rm 커맨드에 label 판단 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 환경 변수를 레이블 기반으로 삭제할 수 있는 기능 추가.
	- `--label` 플래그를 사용하여 레이블을 지정할 수 있는 기능 추가.
	- 환경 변수 추가 명령에서 레이블 플래그를 단일 형태로 통합.

- **버그 수정**
	- 레이블 플래그 변경에 따른 오류 메시지 처리 유지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->