### PR TITLE
🔀 :: [#120] - env 수정 커맨드에 label 플래그 추가

### DIFF
--- a/api/exec/update_env.go
+++ b/api/exec/update_env.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+type updateEnvRequest struct {
+	NewValue string `json:"newValue"`
+}
+
 func UpdateEnv(workspaceId string, applicationId string, key string, value string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
@@ -14,15 +18,13 @@ func UpdateEnv(workspaceId string, applicationId string, key string, value strin
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	body := map[string]string{}
-	body["newValue"] = value
-	envReq := envRequest{EnvList: body}
-	requestJson, err := json.Marshal(envReq)
+	updateEnvReq := updateEnvRequest{NewValue: value}
+	requestJson, err := json.Marshal(updateEnvReq)
 
 	param := map[string]string{}
 	param["key"] = key
 
-	_, err = api.SendPatch("/"+workspaceId+"/application/"+applicationId+"/env?key="+key, header, param, requestJson)
+	_, err = api.SendPatch("/"+workspaceId+"/application/"+applicationId+"/env", header, param, requestJson)
 	if err != nil {
 		return err
 	}
@@ -38,16 +40,14 @@ func UpdateEnvWithLabel(workspaceId string, labels []string, key string, value s
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	body := map[string]string{}
-	body["newValue"] = value
-	envReq := envRequest{EnvList: body}
-	requestJson, err := json.Marshal(envReq)
+	updateEnvReq := updateEnvRequest{NewValue: value}
+	requestJson, err := json.Marshal(updateEnvReq)
 
 	param := map[string]string{}
 	param["key"] = key
 	param["labels"] = strings.Join(labels, ",")
 
-	_, err = api.SendPatch("/"+workspaceId+"/application/env?key="+key, header, param, requestJson)
+	_, err = api.SendPatch("/"+workspaceId+"/application/env", header, param, requestJson)
 	if err != nil {
 		return err
 	}

--- a/api/exec/update_env.go
+++ b/api/exec/update_env.go
@@ -21,6 +21,10 @@ func UpdateEnv(workspaceId string, applicationId string, key string, value strin
 	updateEnvReq := updateEnvRequest{NewValue: value}
 	requestJson, err := json.Marshal(updateEnvReq)
 
+	if err != nil {
+		return err
+	}
+
 	param := map[string]string{}
 	param["key"] = key
 
@@ -42,6 +46,10 @@ func UpdateEnvWithLabel(workspaceId string, labels []string, key string, value s
 
 	updateEnvReq := updateEnvRequest{NewValue: value}
 	requestJson, err := json.Marshal(updateEnvReq)
+
+	if err != nil {
+		return err
+	}
 
 	param := map[string]string{}
 	param["key"] = key

--- a/api/exec/update_env.go
+++ b/api/exec/update_env.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"encoding/json"
 	"github.com/dolong2/dcd-cli/api"
+	"strings"
 )
 
 func UpdateEnv(workspaceId string, applicationId string, key string, value string) error {
@@ -21,7 +22,32 @@ func UpdateEnv(workspaceId string, applicationId string, key string, value strin
 	param := map[string]string{}
 	param["key"] = key
 
-	_, err = api.SendPatch("/"+workspaceId+"/application/"+applicationId+"/env?key="+key, header, map[string]string{}, requestJson)
+	_, err = api.SendPatch("/"+workspaceId+"/application/"+applicationId+"/env?key="+key, header, param, requestJson)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func UpdateEnvWithLabel(workspaceId string, labels []string, key string, value string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	body := map[string]string{}
+	body["newValue"] = value
+	envReq := envRequest{EnvList: body}
+	requestJson, err := json.Marshal(envReq)
+
+	param := map[string]string{}
+	param["key"] = key
+	param["labels"] = strings.Join(labels, ",")
+
+	_, err = api.SendPatch("/"+workspaceId+"/application/env?key="+key, header, param, requestJson)
 	if err != nil {
 		return err
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -109,11 +109,10 @@ func init() {
 	updateCmd.Flags().StringP("template", "", "", "resource template to json")
 
 	envCmd.AddCommand(updateEnvCmd)
-
-	updateEnvCmd.Flags().StringP("key", "", "", "select a key to delete")
 	updateEnvCmd.Flags().StringP("workspace", "w", "", "workspace id")
+	updateEnvCmd.Flags().StringP("key", "", "", "select a key to update")
+	updateEnvCmd.Flags().StringP("value", "", "", "select a value to update")
 
 	globalEnvCmd.AddCommand(updateGlobalEnvCmd)
-
 	updateGlobalEnvCmd.Flags().StringP("key", "", "", "select a key to delete")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -54,15 +54,28 @@ var updateEnvCmd = &cobra.Command{
 			return err
 		}
 
-		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
-		}
-		application := args[0]
 		key, existsKey := cmd.Flags().GetString("key")
 		value, existsValue := cmd.Flags().GetString("value")
 		if key == "" || value == "" || existsKey != nil || existsValue != nil {
 			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
 		}
+
+		labels, err := cmd.Flags().GetStringArray("label")
+		if err != nil {
+			return err
+		}
+		if len(labels) != 0 {
+			err := exec.UpdateEnvWithLabel(workspaceId, labels, key, value)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if len(args) == 0 {
+			return cmdError.NewCmdError(1, "must specify applicationId")
+		}
+		application := args[0]
 		err = exec.UpdateEnv(workspaceId, application, key, value)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
@@ -112,7 +125,9 @@ func init() {
 	updateEnvCmd.Flags().StringP("workspace", "w", "", "workspace id")
 	updateEnvCmd.Flags().StringP("key", "", "", "select a key to update")
 	updateEnvCmd.Flags().StringP("value", "", "", "select a value to update")
+	updateEnvCmd.Flags().StringArrayP("label", "l", []string{}, "select labels for applications.\nif use this flag, you are no need to use application id.\nex). -l test-label-1 -l test-label-2")
 
 	globalEnvCmd.AddCommand(updateGlobalEnvCmd)
 	updateGlobalEnvCmd.Flags().StringP("key", "", "", "select a key to delete")
+	updateGlobalEnvCmd.Flags().StringP("value", "", "", "select a value to update")
 }


### PR DESCRIPTION
## 개요
* env 수정 커맨드에 label 플래그 추가
## 작업내용
* env 수정 커맨드에 value 플래그 추가
* 라벨로 애플리케이션 환경변수를 수정하는 API 호출 메서드 추가
* env 업데이트 메서드 수정
* 애플리케이션 환경변수 수정 커맨드에 label 판단 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 환경 변수를 업데이트하는 새로운 요청 유형 `updateEnvRequest` 추가.
	- 레이블을 포함하여 환경 변수를 업데이트하는 `UpdateEnvWithLabel` 함수 추가.
	- 환경 변수 업데이트 명령어에 레이블 플래그 추가.

- **버그 수정**
	- 명령어 실행 시 오류 메시지를 명확하게 수정. 

이 업데이트는 환경 변수 관리의 유연성을 향상시키며, 사용자가 레이블을 통해 더 쉽게 업데이트할 수 있도록 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->