### PR TITLE
🔀 :: [#124] - 웹소켓으로 애플리케이션 접근시 커맨드 인식이 제대로 되지 않는 현상 수정

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -47,10 +47,6 @@ externally this command
 			for {
 				fmt.Print(workingDir + " > ")
 				input, _, _ := reader.ReadLine() // 사용자 입력 받기
-				err := websocket.SendMessage(conn, string(input))
-				if err != nil {
-					return cmdError.NewCmdError(1, err.Error())
-				}
 
 				// 인터럽트 신호 처리 (Ctrl+C)
 				select {
@@ -61,6 +57,11 @@ externally this command
 					}
 					return nil
 				default:
+				}
+
+				err := websocket.SendMessage(conn, string(input))
+				if err != nil {
+					return cmdError.NewCmdError(1, err.Error())
 				}
 
 				for {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -72,7 +72,7 @@ externally this command
 					}
 					if strings.HasPrefix(message, workingDirPrefix) {
 						workingDir = strings.TrimPrefix(message, workingDirPrefix)
-						break
+						continue
 					} else if strings.HasPrefix(message, endPrefix) {
 						break
 					}


### PR DESCRIPTION
## 개요
* 웹소켓으로 애플리케이션 접근시 커맨드 인식이 제대로 되지 않는 현상을 수정합니다.
## 작업내용
* 웹소켓에서 작업 경로를 받을때 break대신 continue를 사용하도록 수정
* 웹소켓을 전송하는 부분을 select 하위로 수정