### PR TITLE
🔀 :: [#126] - 리소스를 생성할때 사용한 템플릿이랑 생성된 리소스의 아이디를 저장할 수 있는 기능 추가

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -50,6 +50,10 @@ type applicationRequest struct {
 	Labels          []string          `json:"labels"`
 }
 
+type createApplicationResponse struct {
+	ApplicationId string `json:"applicationId"`
+}
+
 func CreateByPath(fileDirectory string) error {
 	content, err := os.ReadFile(fileDirectory)
 	if err != nil {

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -129,7 +129,7 @@ func createByJson(content []byte) (string, error) {
 		}
 	} else if resourceType == "APPLICATION" {
 		var application applicationTemplate
-		err := json.Unmarshal(content, &application)
+		err = json.Unmarshal(content, &application)
 		if err != nil {
 			return "", err
 		}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -60,15 +60,16 @@ func CreateByPath(fileDirectory string) error {
 		return err
 	}
 
+	var resourceId = ""
 	ext := filepath.Ext(fileDirectory)
 	switch ext {
 	case ".json":
-		err = createByJson(content)
+		resourceId, err = createByJson(content)
 		if err != nil {
 			return err
 		}
 	case ".yml", ".yaml":
-		err = createByYml(content)
+		resourceId, err = createByYml(content)
 		if err != nil {
 			return err
 		}
@@ -76,11 +77,18 @@ func CreateByPath(fileDirectory string) error {
 		return errors.New("invalid file extension")
 	}
 
+	if resourceId != "" {
+		err := MapFileToResourceId(fileDirectory, resourceId)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func CreateByTemplate(rawTemplate string) error {
-	err := createByJson([]byte(rawTemplate))
+	_, err := createByJson([]byte(rawTemplate))
 	if err != nil {
 		return err
 	}

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -77,4 +78,41 @@ func getWorkspaceId() (string, error) {
 	workspaceId := workspaceInfo["workspaceId"].(string)
 
 	return workspaceId, nil
+}
+
+func MapFileToResourceId(fileDirectory string, resourceId string) error {
+	resourceMappingInfoPath := "./dcd-info/resource-mapping-info.json"
+	fileName := filepath.Base(fileDirectory)
+
+	// JSON 파일 읽기 또는 파일이 없을 경우 새로 생성
+	file, err := os.ReadFile(resourceMappingInfoPath)
+	var data map[string]string
+
+	if os.IsNotExist(err) {
+		// 파일이 없을 경우 초기 맵을 생성
+		data = make(map[string]string)
+	} else if err != nil {
+		return err
+	} else {
+		// 파일이 존재하는 경우 JSON 데이터를 언마셜링
+		if err := json.Unmarshal(file, &data); err != nil {
+			return err
+		}
+	}
+
+	// 새로운 key:value 쌍 추가
+	data[fileName] = resourceId
+
+	// 수정된 맵을 JSON으로 마셜링
+	updatedJSON, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// JSON 파일에 저장
+	if err := os.WriteFile(resourceMappingInfoPath, updatedJSON, 0644); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -81,9 +81,19 @@ func getWorkspaceId() (string, error) {
 }
 
 func MapFileToResourceId(fileDirectory string, resourceId string) error {
-	resourceMappingInfoPath := "./dcd-info/resource-mapping-info.json"
-	fileName := filepath.Base(fileDirectory)
+	if resourceId == "" || fileDirectory == "" {
+		return errors.New("invalid parameter to map resource id")
+	}
 
+	resourceMappingInfoPath := "./dcd-info/resource-mapping-info.json"
+
+	// 디렉토리가 없으면 생성
+	resourceMappingDir := filepath.Dir(resourceMappingInfoPath)
+	if err := os.MkdirAll(resourceMappingDir, 0755); err != nil {
+		return errors.New("failure to create dcd-info directory")
+	}
+
+	fileName := filepath.Base(fileDirectory)
 	// JSON 파일 읽기 또는 파일이 없을 경우 새로 생성
 	file, err := os.ReadFile(resourceMappingInfoPath)
 	var data map[string]string


### PR DESCRIPTION
## 개요
* 리소스를 생성할때 사용한 템플릿이랑 생성된 리소스의 아이디를 저장할 수 있는 기능을 추가합니다.
## 작업내용
* 리소스 아이디랑 파일명을 매핑하는 메서드 추가
* createApplicationResponse 구조체 추가
* createByJson에서 애플리케이션 생성후 아이디를 반환하도록 수정
* createByYml에서 애플리케이션 생성후 아이디를 반환하도록 수정
* 템플릿으로 리소스 생성시 생성된 리소스 아이디랑 템플릿 파일을 매핑하도록 수정
## 기타
* 추후에 서버에서 워크스페이스 생성시에도 리소스 아이디를 반환하도록 수정해서 워크스페이스도 매핑할 수 있도록 수정해야함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 애플리케이션 생성 프로세스를 개선하여 응답에 애플리케이션 ID를 포함하도록 변경.
	- 파일 이름을 리소스 ID에 매핑하는 새로운 기능 추가.

- **버그 수정**
	- 애플리케이션 생성 시 오류 처리 개선 및 응답 관리 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->