### PR TITLE
🔀 :: [#128] - 워크스페이스 생성후 워크스페이스 아이디와 템플릿을 매핑시키는 기능 추가

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -127,10 +127,17 @@ func createByJson(content []byte) (string, error) {
 			return "", err
 		}
 
-		_, err = api.SendPost("/workspace", header, map[string]string{}, request)
+		response, err := api.SendPost("/workspace", header, map[string]string{}, request)
 		if err != nil {
 			return "", err
 		}
+
+		createWorkspaceResponse := createWorkspaceResponse{}
+		err = json.Unmarshal(response, &createWorkspaceResponse)
+		if err != nil {
+			return "", err
+		}
+		return createWorkspaceResponse.WorkspaceId, nil
 	} else if resourceType == "APPLICATION" {
 		var application applicationTemplate
 		err = json.Unmarshal(content, &application)
@@ -170,8 +177,6 @@ func createByJson(content []byte) (string, error) {
 	} else {
 		return "", errors.New(" this resource type is not supported")
 	}
-
-	return "", nil
 }
 
 func createByYml(content []byte) (string, error) {

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -206,10 +206,17 @@ func createByYml(content []byte) (string, error) {
 			return "", err
 		}
 
-		_, err = api.SendPost("/workspace", header, map[string]string{}, request)
+		response, err := api.SendPost("/workspace", header, map[string]string{}, request)
 		if err != nil {
 			return "", err
 		}
+
+		createWorkspaceResponse := createWorkspaceResponse{}
+		err = yaml.Unmarshal(response, &createWorkspaceResponse)
+		if err != nil {
+			return "", err
+		}
+		return createWorkspaceResponse.WorkspaceId, nil
 	} else if resourceType == "APPLICATION" {
 		var application applicationTemplate
 		err := yaml.Unmarshal(content, &application)
@@ -251,6 +258,4 @@ func createByYml(content []byte) (string, error) {
 	} else {
 		return "", errors.New(" this resource type is not supported")
 	}
-
-	return "", nil
 }

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -210,9 +210,8 @@ func createByYml(content []byte) (string, error) {
 		if err != nil {
 			return "", err
 		}
-
 		createWorkspaceResponse := createWorkspaceResponse{}
-		err = yaml.Unmarshal(response, &createWorkspaceResponse)
+		err = json.Unmarshal(response, &createWorkspaceResponse)
 		if err != nil {
 			return "", err
 		}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -50,6 +50,10 @@ type applicationRequest struct {
 	Labels          []string          `json:"labels"`
 }
 
+type createWorkspaceResponse struct {
+	WorkspaceId string `json:"workspaceId"`
+}
+
 type createApplicationResponse struct {
 	ApplicationId string `json:"applicationId"`
 }


### PR DESCRIPTION
## 개요
* 워크스페이스 생성후 워크스페이스 아이디와 템플릿을 매핑시키는 기능을 추가합니다.
## 작업내용
* CreateWorkspaceResponse 구조체 추가
* createByJson 메서드에서 워크스페이스 생성후 워크스페이스 아이디를 반환하도록 수정
* createByYml 메서드에서 워크스페이스 생성후 워크스페이스 아이디를 반환하도록 수정
* 리소스 아이디 파싱시 json.Unmarshal을 사용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 작업 공간 생성 API 응답 처리 개선: 이제 작업 공간 ID가 구조화된 형식으로 반환됩니다.
- **버그 수정**
	- API 응답 처리 시 오류 체크 추가로 안정성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->