### PR TITLE
🔀 :: [#130] - update 커맨드에서 파일 사용시 파일명에 매핑된 리소스 아이디를 찾도록 수정

### DIFF
--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -100,6 +100,10 @@ func UpdateByOnlyPath(fileDirectory string) error {
 	templateName := filepath.Base(fileDirectory)
 	resourceId := data[templateName]
 
+	if resourceId == "" {
+		return errors.New("must enter a resource id")
+	}
+
 	content, err := os.ReadFile(fileDirectory)
 	if err != nil {
 		return err

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -146,7 +146,7 @@ func updateByJson(resourceId string, content []byte) error {
 			return err
 		}
 
-		request, err := json.Marshal(updateWorkspaceRequest{Name: workspace.Metadata.Name, Description: workspace.Metadata.Description})
+		request, err := json.Marshal(updateWorkspaceRequest{Title: workspace.Metadata.Name, Description: workspace.Metadata.Description})
 		if err != nil {
 			return err
 		}
@@ -156,13 +156,18 @@ func updateByJson(resourceId string, content []byte) error {
 			return err
 		}
 	} else if resourceType == "APPLICATION" {
-		var application updateApplicationTemplate
-		err := yaml.Unmarshal(content, &application)
+		workspaceId, err := getWorkspaceId()
 		if err != nil {
 			return err
 		}
 
-		request, err := yaml.Marshal(updateApplicationRequest{
+		var application updateApplicationTemplate
+		err = yaml.Unmarshal(content, &application)
+		if err != nil {
+			return err
+		}
+
+		request, err := json.Marshal(updateApplicationRequest{
 			Name:            application.Metadata.Name,
 			Description:     application.Metadata.Description,
 			GithubUrl:       application.GithubUrl,
@@ -174,7 +179,7 @@ func updateByJson(resourceId string, content []byte) error {
 			return err
 		}
 
-		_, err = api.SendPut("/"+application.WorkspaceId+"/application/"+resourceId, header, map[string]string{}, request)
+		_, err = api.SendPut("/"+workspaceId+"/application/"+resourceId, header, map[string]string{}, request)
 		if err != nil {
 			return err
 		}

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -166,7 +166,7 @@ func updateByJson(resourceId string, content []byte) error {
 		}
 
 		var application updateApplicationTemplate
-		err = yaml.Unmarshal(content, &application)
+		err = json.Unmarshal(content, &application)
 		if err != nil {
 			return err
 		}

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -10,36 +10,35 @@ import (
 )
 
 type updateMetaData struct {
-	ResourceType string `json:"resourceType"`
-	Name         string `json:"name"`
-	Description  string `json:"description"`
+	ResourceType string `json:"resourceType" yaml:"resourceType"`
+	Name         string `json:"name" yaml:"name"`
+	Description  string `json:"description" yaml:"description"`
 }
 
 type parsingUpdateMetaData struct {
-	Metadata updateMetaData `json:"metadata"`
+	Metadata updateMetaData `json:"metadata" yaml:"metadata"`
 }
 
 type updateWorkspaceTemplate struct {
-	Metadata updateMetaData `json:"metadata"`
+	Metadata updateMetaData `json:"metadata" yaml:"metadata"`
 }
 
 type updateWorkspaceRequest struct {
-	ResourceType string `json:"resourceType"`
-	Name         string `json:"title"`
-	Description  string `json:"description"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
 }
 
 type updateApplicationTemplate struct {
-	Metadata        metaData `json:"metadata"`
-	WorkspaceId     string   `json:"workspaceId"`
-	GithubUrl       string   `json:"githubUrl"`
-	ApplicationType string   `json:"applicationType"`
-	Port            int      `json:"port"`
-	Version         string   `json:"version"`
+	Metadata        metaData `json:"metadata" yaml:"metadata"`
+	WorkspaceId     string   `json:"workspaceId" yaml:"workspaceId"`
+	GithubUrl       string   `json:"githubUrl" yaml:"githubUrl"`
+	ApplicationType string   `json:"applicationType" yaml:"applicationType"`
+	Port            int      `json:"port" yaml:"port"`
+	Version         string   `json:"version" yaml:"version"`
 }
 
 type updateApplicationRequest struct {
-	Name            string            `json:"title"`
+	Name            string            `json:"name"`
 	Description     string            `json:"description"`
 	GithubUrl       string            `json:"githubUrl"`
 	Env             map[string]string `json:"env"`

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -212,7 +212,7 @@ func updateByYml(resourceId string, content []byte) error {
 			return err
 		}
 
-		request, err := yaml.Marshal(updateWorkspaceRequest{Name: workspace.Metadata.Name, Description: workspace.Metadata.Description})
+		request, err := json.Marshal(updateWorkspaceRequest{Title: workspace.Metadata.Name, Description: workspace.Metadata.Description})
 		if err != nil {
 			return err
 		}
@@ -222,13 +222,18 @@ func updateByYml(resourceId string, content []byte) error {
 			return err
 		}
 	} else if resourceType == "APPLICATION" {
-		var application updateApplicationTemplate
-		err := yaml.Unmarshal(content, &application)
+		workspaceId, err := getWorkspaceId()
 		if err != nil {
 			return err
 		}
 
-		request, err := yaml.Marshal(updateApplicationRequest{
+		var application updateApplicationTemplate
+		err = yaml.Unmarshal(content, &application)
+		if err != nil {
+			return err
+		}
+
+		request, err := json.Marshal(updateApplicationRequest{
 			Name:            application.Metadata.Name,
 			Description:     application.Metadata.Description,
 			GithubUrl:       application.GithubUrl,
@@ -240,7 +245,7 @@ func updateByYml(resourceId string, content []byte) error {
 			return err
 		}
 
-		_, err = api.SendPut("/"+application.WorkspaceId+"/application/"+resourceId, header, map[string]string{}, request)
+		_, err = api.SendPut("/"+workspaceId+"/application/"+resourceId, header, map[string]string{}, request)
 		if err != nil {
 			return err
 		}

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -82,6 +82,49 @@ func UpdateByPath(workspaceId string, fileDirectory string) error {
 	return nil
 }
 
+func UpdateByOnlyPath(fileDirectory string) error {
+	// JSON 파일 경로
+	filePath := "./dcd-info/resource-mapping-info.json"
+
+	// JSON 파일 읽기
+	resourceMappingInfo, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	// JSON 데이터 언마샬링
+	var data map[string]string
+	if err := json.Unmarshal(resourceMappingInfo, &data); err != nil {
+		return err
+	}
+
+	templateName := filepath.Base(fileDirectory)
+	resourceId := data[templateName]
+
+	content, err := os.ReadFile(fileDirectory)
+	if err != nil {
+		return err
+	}
+
+	ext := filepath.Ext(fileDirectory)
+	switch ext {
+	case ".json":
+		err = updateByJson(resourceId, content)
+		if err != nil {
+			return err
+		}
+	case ".yml", ".yaml":
+		err = updateByYml(resourceId, content)
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("invalid file extension")
+	}
+
+	return nil
+}
+
 func updateByJson(resourceId string, content []byte) error {
 	var data parsingUpdateMetaData
 	err := json.Unmarshal(content, &data)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -13,17 +13,23 @@ var updateCmd = &cobra.Command{
 	Short: "command to update a resource",
 	Long:  `this command is used to update a resource`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return cmdError.NewCmdError(1, "must enter both resource type and resource id")
-		}
-
-		resourceId := args[0]
-
 		fileDirectory, fileErr := cmd.Flags().GetString("file")
 		template, templateErr := cmd.Flags().GetString("template")
 		if fileErr != nil || templateErr != nil {
 			return cmdError.NewCmdError(2, "invalid flag")
 		}
+
+		// args가 없다면 파일명에 매핑된 리소스 아이디를 가져오는 메서드 호출
+		if len(args) < 1 {
+			err := exec.UpdateByOnlyPath(fileDirectory)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
+			return nil
+		}
+
+		resourceId := args[0]
+
 		if fileDirectory == "" && template == "" {
 			err := cmdError.NewCmdError(1, "there must be required either file flag or template flag")
 			return err


### PR DESCRIPTION
## 개요
* update 커맨드에서 파일 사용시 템플릿 이름에 매핑된 리소스 아이디를 사용해서 활용하도록 수정합니다.
## 작업내용
* UpdateByOnlyPath 메서드 추가
* update에 사용할 구조체 수정
* updateByJson 메서드 수정
* updateByYml 메서드 수정
* update cmd 수정
* 만약 템플릿에 매핑된 리소스 아이디가 없다면 에러를 리턴하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
	- YAML 직렬화를 지원하기 위해 메타데이터 구조가 향상되었습니다.
	- `UpdateByOnlyPath` 함수가 추가되어 JSON 및 YAML 파일을 처리할 수 있습니다.
	- `updateCmd` 명령이 인자 없이도 작동할 수 있도록 개선되었습니다.

- **버그 수정**
	- 오류 처리 로직이 개선되어 명확한 오류 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->