### PR TITLE
🔀 :: [#132] - 파일명에 매핑된 리소스 아이디를 가져오는 메서드 추가

### DIFF
--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -82,25 +82,9 @@ func UpdateByPath(workspaceId string, fileDirectory string) error {
 }
 
 func UpdateByOnlyPath(fileDirectory string) error {
-	// JSON 파일 경로
-	filePath := "./dcd-info/resource-mapping-info.json"
+	resourceId, err := GetResourceIdByFilePath(fileDirectory)
 
-	// JSON 파일 읽기
-	resourceMappingInfo, err := os.ReadFile(filePath)
 	if err != nil {
-		return err
-	}
-
-	// JSON 데이터 언마샬링
-	var data map[string]string
-	if err := json.Unmarshal(resourceMappingInfo, &data); err != nil {
-		return err
-	}
-
-	templateName := filepath.Base(fileDirectory)
-	resourceId := data[templateName]
-
-	if resourceId == "" {
 		return errors.New("must enter a resource id")
 	}
 

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -85,7 +85,7 @@ func UpdateByOnlyPath(fileDirectory string) error {
 	resourceId, err := GetResourceIdByFilePath(fileDirectory)
 
 	if err != nil {
-		return errors.New("must enter a resource id")
+		return errors.New("there are no files mapped to the resource id")
 	}
 
 	content, err := os.ReadFile(fileDirectory)

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -126,3 +126,29 @@ func MapFileToResourceId(fileDirectory string, resourceId string) error {
 
 	return nil
 }
+
+func GetResourceIdByFilePath(fileDirectory string) (string, error) {
+	// JSON 파일 경로
+	filePath := "./dcd-info/resource-mapping-info.json"
+
+	// JSON 파일 읽기
+	resourceMappingInfo, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	// JSON 데이터 언마샬링
+	var data map[string]string
+	if err := json.Unmarshal(resourceMappingInfo, &data); err != nil {
+		return "", err
+	}
+
+	templateName := filepath.Base(fileDirectory)
+	resourceId := data[templateName]
+
+	if resourceId == "" {
+		return "", errors.New("해당 템플릿에 매핑된 리소스 아이디를 찾을 수 없음")
+	}
+
+	return resourceId, nil
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -21,6 +21,9 @@ var updateCmd = &cobra.Command{
 
 		// args가 없다면 파일명에 매핑된 리소스 아이디를 가져오는 메서드 호출
 		if len(args) < 1 {
+			if fileDirectory == "" {
+				return cmdError.NewCmdError(1, "resource id can be omitted only when use a file flag")
+			}
 			err := exec.UpdateByOnlyPath(fileDirectory)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())


### PR DESCRIPTION
## 개요
* 파일명에 매핑된 리소스 아이디를 가져오는 메서드를 추가합니다.
## 작업내용
* GetResourceIdByFilePath 메서드 추가
* UpdateByOnlyPath 메서드에 GetResourceIdByFilePath 메서드 적용
* update cmd에서 args가 생략됐을때 파일 플래그를 사용하는지 검증하는 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 파일 경로에 따라 리소스 ID를 직접 조회하는 새로운 기능 추가.
- **버그 수정**
	- 명령어 입력 검증 로직 개선: 파일 경로가 비어있을 경우 리소스 ID가 필수로 요구됨.
- **문서화**
	- 새로운 함수 `GetResourceIdByFilePath`에 대한 설명 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->