### PR TITLE
🔀 :: [#134] - 지원되지 않는 리소스 타입일때 에러가 발생하는 로직 추가

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -35,6 +35,8 @@ var deleteCmd = &cobra.Command{
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
 			}
+		} else {
+			return cmdError.NewCmdError(1, "invalid resource type")
 		}
 
 		return nil

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -36,6 +36,8 @@ resourceType:
 			if err != nil {
 				return err
 			}
+		} else {
+			return cmdError.NewCmdError(1, "invalid resource type")
 		}
 
 		return nil


### PR DESCRIPTION
## 개요
* 지원되지 않는 리소스 타입일때 에러가 발생하는 로직을 추가합니다.
## 작업내용
* delete cmd에서 지원하지 않는 리소스 타입일때 에러를 발생시키는 로직 추가
* get cmd에서 지원하지 않는 리소스 타입일때 에러를 발생시키는 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 삭제 및 가져오기 명령에서 잘못된 리소스 유형에 대한 오류 처리를 추가하여 사용자에게 유효하지 않은 리소스 유형을 입력할 경우 피드백을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->