### PR TITLE
🔀 :: [#136] - 에러 문구를 한국어로 수정

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -175,7 +175,7 @@ func createByJson(content []byte) (string, error) {
 		}
 		return createApplicationResponse.ApplicationId, nil
 	} else {
-		return "", errors.New(" this resource type is not supported")
+		return "", errors.New("지원되지 않는 리소스 타입입니다.")
 	}
 }
 
@@ -255,6 +255,6 @@ func createByYml(content []byte) (string, error) {
 		}
 		return createApplicationResponse.ApplicationId, nil
 	} else {
-		return "", errors.New(" this resource type is not supported")
+		return "", errors.New("지원되지 않는 리소스 타입입니다.")
 	}
 }

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -75,7 +75,7 @@ func UpdateByPath(workspaceId string, fileDirectory string) error {
 			return err
 		}
 	default:
-		return errors.New("invalid file extension")
+		return errors.New("지원되지 않는 파일 확장자입니다.")
 	}
 
 	return nil
@@ -85,7 +85,7 @@ func UpdateByOnlyPath(fileDirectory string) error {
 	resourceId, err := GetResourceIdByFilePath(fileDirectory)
 
 	if err != nil {
-		return errors.New("there are no files mapped to the resource id")
+		return errors.New("파일이랑 매핑되는 리소스 아이디가 존재하지 않습니다.")
 	}
 
 	content, err := os.ReadFile(fileDirectory)
@@ -106,7 +106,7 @@ func UpdateByOnlyPath(fileDirectory string) error {
 			return err
 		}
 	default:
-		return errors.New("invalid file extension")
+		return errors.New("지원되지 않는 파일 확장자입니다.")
 	}
 
 	return nil
@@ -172,7 +172,7 @@ func updateByJson(resourceId string, content []byte) error {
 			return err
 		}
 	} else {
-		return errors.New(" this resource type is not supported")
+		return errors.New("지원되지 않는 리소스 타입입니다.")
 	}
 
 	return nil
@@ -238,7 +238,7 @@ func updateByYml(resourceId string, content []byte) error {
 			return err
 		}
 	} else {
-		return errors.New(" this resource type is not supported")
+		return errors.New("지원되지 않는 리소스 타입입니다.")
 	}
 
 	return nil

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -65,14 +65,14 @@ getTokenInfo:
 func getWorkspaceId() (string, error) {
 	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
 	if err != nil {
-		return "", errors.New("not found workspace info")
+		return "", errors.New("워크스페이스 정보를 찾을수없습니다.")
 	}
 
 	var workspaceInfo map[string]interface{}
 
 	err = json.Unmarshal(rawWorkspaceInfo, &workspaceInfo)
 	if err != nil {
-		return "", errors.New("invalid workspace info")
+		return "", errors.New("워크스페이스 정보가 옳바르지 않습니다.")
 	}
 
 	workspaceId := workspaceInfo["workspaceId"].(string)
@@ -82,7 +82,7 @@ func getWorkspaceId() (string, error) {
 
 func MapFileToResourceId(fileDirectory string, resourceId string) error {
 	if resourceId == "" || fileDirectory == "" {
-		return errors.New("invalid parameter to map resource id")
+		return errors.New("리소스 아이디와 파일경로는 필수적으로 입력되어야합니다.")
 	}
 
 	resourceMappingInfoPath := "./dcd-info/resource-mapping-info.json"
@@ -90,7 +90,7 @@ func MapFileToResourceId(fileDirectory string, resourceId string) error {
 	// 디렉토리가 없으면 생성
 	resourceMappingDir := filepath.Dir(resourceMappingInfoPath)
 	if err := os.MkdirAll(resourceMappingDir, 0755); err != nil {
-		return errors.New("failure to create dcd-info directory")
+		return errors.New("dcd-info 정보 디렉토리를 생성하는데 실패했습니다.")
 	}
 
 	fileName := filepath.Base(fileDirectory)

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -72,7 +72,7 @@ func getWorkspaceId() (string, error) {
 
 	err = json.Unmarshal(rawWorkspaceInfo, &workspaceInfo)
 	if err != nil {
-		return "", errors.New("워크스페이스 정보가 옳바르지 않습니다.")
+		return "", errors.New("워크스페이스 정보가 올바르지 않습니다.")
 	}
 
 	workspaceId := workspaceInfo["workspaceId"].(string)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -21,7 +21,7 @@ var addCmd = &cobra.Command{
 		key, keyErr := cmd.Flags().GetString("key")
 		value, valueErr := cmd.Flags().GetString("value")
 		if key == "" || value == "" || keyErr != nil || valueErr != nil {
-			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
+			return cmdError.NewCmdError(1, "환경변수의 키와 값이 전부 입력되어야합니다.")
 		}
 
 		labels, err := cmd.Flags().GetStringArray("label")
@@ -39,7 +39,7 @@ var addCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		application := args[0]
 		err = exec.AddEnv(workspaceId, application, key, value)
@@ -72,7 +72,7 @@ var addGlobalEnvCmd = &cobra.Command{
 		key, existsKey := cmd.Flags().GetString("key")
 		value, existsValue := cmd.Flags().GetString("value")
 		if key == "" || value == "" || existsKey != nil || existsValue != nil {
-			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
+			return cmdError.NewCmdError(1, "환경변수의 키와 값이 전부 입력되어야합니다.")
 		}
 		err := exec.AddEnv(workspaceId, application, key, value)
 		if err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,10 +15,10 @@ var createCmd = &cobra.Command{
 		fileDirectory, fileErr := cmd.Flags().GetString("file")
 		template, templateErr := cmd.Flags().GetString("template")
 		if fileErr != nil || templateErr != nil {
-			return cmdError.NewCmdError(2, "옳바르지 않은 플래그입니다.")
+			return cmdError.NewCmdError(2, "올바르지 않은 플래그입니다.")
 		}
 		if fileDirectory == "" && template == "" {
-			err := cmdError.NewCmdError(1, "파일 플래그나 템플릿 플래그중 하나는 입력되어야합니다.")
+			err := cmdError.NewCmdError(1, "파일 플래그나 템플릿 플래그 중 하나는 입력되어야합니다.")
 			return err
 		} else if fileDirectory != "" {
 			err := exec.CreateByPath(fileDirectory)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,10 +15,10 @@ var createCmd = &cobra.Command{
 		fileDirectory, fileErr := cmd.Flags().GetString("file")
 		template, templateErr := cmd.Flags().GetString("template")
 		if fileErr != nil || templateErr != nil {
-			return cmdError.NewCmdError(2, "invalid flag")
+			return cmdError.NewCmdError(2, "옳바르지 않은 플래그입니다.")
 		}
 		if fileDirectory == "" && template == "" {
-			err := cmdError.NewCmdError(1, "there must be required either file flag or template flag")
+			err := cmdError.NewCmdError(1, "파일 플래그나 템플릿 플래그중 하나는 입력되어야합니다.")
 			return err
 		} else if fileDirectory != "" {
 			err := exec.CreateByPath(fileDirectory)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,7 +14,7 @@ var deleteCmd = &cobra.Command{
 	Long:  `this command will delete an resource.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return cmdError.NewCmdError(1, "must enter both resource type and resource id")
+			return cmdError.NewCmdError(1, "리소스 타입과 리소스 아이디가 입력되어야합니다.")
 		}
 
 		resourceType := args[0]
@@ -36,7 +36,7 @@ var deleteCmd = &cobra.Command{
 				return cmdError.NewCmdError(1, err.Error())
 			}
 		} else {
-			return cmdError.NewCmdError(1, "invalid resource type")
+			return cmdError.NewCmdError(1, "옳바르지 않은 리소스 타입입니다.")
 		}
 
 		return nil

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -36,7 +36,7 @@ var deleteCmd = &cobra.Command{
 				return cmdError.NewCmdError(1, err.Error())
 			}
 		} else {
-			return cmdError.NewCmdError(1, "옳바르지 않은 리소스 타입입니다.")
+			return cmdError.NewCmdError(1, "올바르지 않은 리소스 타입입니다.")
 		}
 
 		return nil

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -31,7 +31,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		applicationId := args[0]
 		err = exec.DeployApplication(workspaceId, applicationId)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -23,7 +23,7 @@ externally this command
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		applicationId := args[0]
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -37,7 +37,7 @@ resourceType:
 				return err
 			}
 		} else {
-			return cmdError.NewCmdError(1, "옳바르지 않은 리소스 타입입니다.")
+			return cmdError.NewCmdError(1, "올바르지 않은 리소스 타입입니다.")
 		}
 
 		return nil

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -22,7 +22,7 @@ resourceType:
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify resource type")
+			return cmdError.NewCmdError(1, "리소스 타입이 입력되어야 합니다.")
 		}
 		resourceType := args[0]
 
@@ -37,7 +37,7 @@ resourceType:
 				return err
 			}
 		} else {
-			return cmdError.NewCmdError(1, "invalid resource type")
+			return cmdError.NewCmdError(1, "옳바르지 않은 리소스 타입입니다.")
 		}
 
 		return nil

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,8 +17,8 @@ var loginCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		email, emailErr := cmd.Flags().GetString("email")
 		existsPassword, passwordErr := cmd.Flags().GetBool("password")
-		if emailErr != nil || passwordErr != nil {
-			return cmdError.NewCmdError(1, "invalid flag")
+		if email == "" || emailErr != nil || passwordErr != nil {
+			return cmdError.NewCmdError(1, "옳바르지 않은 플래그입니다.")
 		}
 		password := ""
 		if existsPassword {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -18,7 +18,7 @@ var loginCmd = &cobra.Command{
 		email, emailErr := cmd.Flags().GetString("email")
 		existsPassword, passwordErr := cmd.Flags().GetBool("password")
 		if email == "" || emailErr != nil || passwordErr != nil {
-			return cmdError.NewCmdError(1, "옳바르지 않은 플래그입니다.")
+			return cmdError.NewCmdError(1, "올바르지 않은 플래그입니다.")
 		}
 		password := ""
 		if existsPassword {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -21,7 +21,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		applicationId := args[0]
 		logs, err := exec.GetLog(workspaceId, applicationId)

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -20,7 +20,7 @@ var rmCmd = &cobra.Command{
 
 		envKey, err := cmd.Flags().GetString("key")
 		if err != nil || envKey == "" {
-			return cmdError.NewCmdError(1, "should specify envKey")
+			return cmdError.NewCmdError(1, "환경변수 키가 입력되어야합니다.")
 		}
 
 		labels, err := cmd.Flags().GetStringArray("label")
@@ -37,7 +37,7 @@ var rmCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		applicationId := args[0]
 
@@ -70,7 +70,7 @@ var rmGlobalEnvCmd = &cobra.Command{
 
 		envKey, err := cmd.Flags().GetString("key")
 		if err != nil || envKey == "" {
-			return cmdError.NewCmdError(1, "should specify envKey")
+			return cmdError.NewCmdError(1, "환경변수 키가 입력되어야합니다.")
 		}
 
 		err = exec.RemoveGlobalEnv(workspaceId, envKey)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,7 +33,7 @@ var runCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		applicationId := args[0]
 		err = exec.RunApplication(workspaceId, applicationId)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -32,7 +32,7 @@ var stopCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		applicationId := args[0]
 		err = exec.StopApplication(workspaceId, applicationId)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,13 +16,13 @@ var updateCmd = &cobra.Command{
 		fileDirectory, fileErr := cmd.Flags().GetString("file")
 		template, templateErr := cmd.Flags().GetString("template")
 		if fileErr != nil || templateErr != nil {
-			return cmdError.NewCmdError(2, "invalid flag")
+			return cmdError.NewCmdError(2, "옳바르지 않은 플래그입니다.")
 		}
 
 		// args가 없다면 파일명에 매핑된 리소스 아이디를 가져오는 메서드 호출
 		if len(args) < 1 {
 			if fileDirectory == "" {
-				return cmdError.NewCmdError(1, "resource id can be omitted only when use a file flag")
+				return cmdError.NewCmdError(1, "리소스 아이디는 파일 플래그를 사용할때만 생략할 수 있습니다.")
 			}
 			err := exec.UpdateByOnlyPath(fileDirectory)
 			if err != nil {
@@ -34,7 +34,7 @@ var updateCmd = &cobra.Command{
 		resourceId := args[0]
 
 		if fileDirectory == "" && template == "" {
-			err := cmdError.NewCmdError(1, "there must be required either file flag or template flag")
+			err := cmdError.NewCmdError(1, "파일 플래그나 템플릿 플래그가 있어야합니다.")
 			return err
 		} else if fileDirectory != "" {
 			err := exec.UpdateByPath(resourceId, fileDirectory)
@@ -66,7 +66,7 @@ var updateEnvCmd = &cobra.Command{
 		key, existsKey := cmd.Flags().GetString("key")
 		value, existsValue := cmd.Flags().GetString("value")
 		if key == "" || value == "" || existsKey != nil || existsValue != nil {
-			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
+			return cmdError.NewCmdError(1, "환경변수의 키와 값이 입력되어야합니다.")
 		}
 
 		labels, err := cmd.Flags().GetStringArray("label")
@@ -82,7 +82,7 @@ var updateEnvCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			return cmdError.NewCmdError(1, "must specify applicationId")
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		application := args[0]
 		err = exec.UpdateEnv(workspaceId, application, key, value)
@@ -114,7 +114,7 @@ var updateGlobalEnvCmd = &cobra.Command{
 		key, existsKey := cmd.Flags().GetString("key")
 		value, existsValue := cmd.Flags().GetString("value")
 		if key == "" || value == "" || existsKey != nil || existsValue != nil {
-			return cmdError.NewCmdError(1, "this command needs to specify both and key and value")
+			return cmdError.NewCmdError(1, "환경변수의 키와 값이 입력되어야합니다.")
 		}
 		err := exec.UpdateGlobalEnv(workspaceId, key, value)
 		if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,7 +16,7 @@ var updateCmd = &cobra.Command{
 		fileDirectory, fileErr := cmd.Flags().GetString("file")
 		template, templateErr := cmd.Flags().GetString("template")
 		if fileErr != nil || templateErr != nil {
-			return cmdError.NewCmdError(2, "옳바르지 않은 플래그입니다.")
+			return cmdError.NewCmdError(2, "올바르지 않은 플래그입니다.")
 		}
 
 		// args가 없다면 파일명에 매핑된 리소스 아이디를 가져오는 메서드 호출

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -14,11 +14,11 @@ var useCmd = &cobra.Command{
 	Long:  `this command can be used to specify which workspace to primarily use.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return cmdError.NewCmdError(1, "must be specify workspaceId")
+			return cmdError.NewCmdError(1, "워크스페이스 아이디가 입력되어야합니다.")
 		}
 		workspaceId := args[0]
 		if workspaceId == "" || workspaceId == " " {
-			return cmdError.NewCmdError(1, "must be specify workspaceId")
+			return cmdError.NewCmdError(1, "워크스페이스 아이디가 입력되어야합니다.")
 		}
 
 		workspace, err := exec.GetWorkspace(workspaceId)

--- a/cmd/util/get_workspace_info.go
+++ b/cmd/util/get_workspace_info.go
@@ -13,7 +13,7 @@ func GetWorkspaceId(cmd *cobra.Command) (string, error) {
 	if err != nil || workspaceId == "" {
 		workspaceId, err = getWorkspaceInfo()
 		if err != nil {
-			return "", cmdError.NewCmdError(1, "must specify workspace id")
+			return "", cmdError.NewCmdError(1, "워크스페이스 아이디가 입력되어야합니다.")
 		}
 	}
 	return workspaceId, nil
@@ -22,14 +22,14 @@ func GetWorkspaceId(cmd *cobra.Command) (string, error) {
 func getWorkspaceInfo() (string, error) {
 	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
 	if err != nil {
-		return "", errors.New("not found workspace info")
+		return "", errors.New("워크스페이스 정보를 찾을 수 없습니다.")
 	}
 
 	var simpleWorkspaceInfo SimpleWorkspaceInfo
 
 	err = json.Unmarshal(rawWorkspaceInfo, &simpleWorkspaceInfo)
 	if err != nil {
-		return "", errors.New("invalid workspace info")
+		return "", errors.New("옳바르지 않은 워크스페이스 정보입니다.")
 	}
 
 	return simpleWorkspaceInfo.WorkspaceId, nil

--- a/cmd/util/get_workspace_info.go
+++ b/cmd/util/get_workspace_info.go
@@ -29,7 +29,7 @@ func getWorkspaceInfo() (string, error) {
 
 	err = json.Unmarshal(rawWorkspaceInfo, &simpleWorkspaceInfo)
 	if err != nil {
-		return "", errors.New("옳바르지 않은 워크스페이스 정보입니다.")
+		return "", errors.New("올바르지 않은 워크스페이스 정보입니다.")
 	}
 
 	return simpleWorkspaceInfo.WorkspaceId, nil


### PR DESCRIPTION
## 개요
* 에러 문구를 한국어로 수정합니다.
## 작업내용
* get_workspace_info의 에러 문구를 한국어로 수정
* cmd의 에러 문구를 한국어로 수정
* API 호출시 발생하는 에러 문구를 한국어로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자에게 지원되지 않는 리소스 타입에 대한 오류 메시지를 한국어로 제공하여 사용자 경험을 향상시킴.
  
- **버그 수정**
	- 여러 명령어에서 잘못된 플래그 및 필수 인자 누락에 대한 오류 메시지를 한국어로 번역하여 제공.
  
- **문서화**
	- 오류 메시지의 로컬라이제이션을 통해 한국어 사용자를 위한 명확한 피드백 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->