### PR TITLE
🔀 :: [#145] - 애플리케이션 타입을 조회하는 커맨드

### DIFF
--- a/api/exec/get_types.go
+++ b/api/exec/get_types.go
@@ -1,0 +1,32 @@
+package exec
+
+import (
+	"encoding/json"
+	"github.com/dolong2/dcd-cli/api"
+)
+
+type getTypesResponse struct {
+	List []string `json:"list"`
+}
+
+func GetTypes() ([]string, error) {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	response, err := api.SendGet("/application/types", header, map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+
+	var typesResponse getTypesResponse
+	err = json.Unmarshal(response, &typesResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return typesResponse.List, nil
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -209,3 +209,22 @@ func printWorkspaceList(workspaceList []exec.WorkspaceResponse, usedWorkspaceId 
 
 	table.Render()
 }
+
+func printApplicationTypes() error {
+	types, err := exec.GetTypes()
+
+	if err != nil {
+		return err
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Types"})
+
+	for _, typeValue := range types {
+		table.Append([]string{typeValue})
+	}
+
+	table.Render()
+
+	return nil
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -36,6 +36,11 @@ var getCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+		} else if resourceType == "types" {
+			err := printApplicationTypes()
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
 		} else {
 			return cmdError.NewCmdError(1, "올바르지 않은 리소스 타입입니다.")
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -19,6 +19,7 @@ var getCmd = &cobra.Command{
 리소스 타입:
 	workspaces - 이 리소스 타입은 여러 애플리케이션을 가지고, 작업구역(네트워크)를 나눌때 사용합니다.
 	applications - 이 리소스 타입은 특정 라이브러리 혹은 프레임워크가 컨테이너에서 동작하게 하는 리소스 타입입니다.
+	types - 애플리케이션의 타입 종류를 나타내는 리소스 타입입니다.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {


### PR DESCRIPTION
## 개요
* 애플리케이션 타입을 조회하는 커맨드를 추가합니다.
## 작업내용
* GetTypes 메서드 추가
* printApplicationTypes 메서드 추가
* resource type에서 types를 지원하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 응용 프로그램 유형을 조회할 수 있는 기능이 추가되었습니다.
	- 명령줄 인터페이스에 새로운 옵션이 도입되어, "types" 리소스 요청 시 조회된 유형이 깔끔한 테이블 형식으로 출력됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->