### PR TITLE
🔀 :: [#147] - 버전 리스트 출력시 테이블 적용

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 // versionCmd represents the version command
@@ -23,9 +24,14 @@ var versionCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, err.Error())
 		}
 
-		for _, version := range versionList {
-			fmt.Println(version)
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{resourceType + " Version List"})
+
+		for _, versionValue := range versionList {
+			table.Append([]string{versionValue})
 		}
+
+		table.Render()
 
 		return nil
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -31,6 +31,7 @@ var versionCmd = &cobra.Command{
 			table.Append([]string{versionValue})
 		}
 
+		table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT})
 		table.Render()
 
 		return nil


### PR DESCRIPTION
## 개요
* 버전 리스트를 출력할때 테이블 포맷을 적용합니다.
## 작업내용
* version 출력시 table로 렌더링하도록 수정
* 테이블 컬럼에 좌측 정렬 적용