### PR TITLE
🔀 :: [#163] - 베이스 url을 dcd-api url로 수정

### DIFF
--- a/api/api_client.go
+++ b/api/api_client.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 )
 
-var baseUrl = "http://localhost:8081"
+var baseUrl = "https://dcd-api.dolong2.co.kr"
 
 type apiErrorResponse struct {
 	Status  int    `json:"status"`


### PR DESCRIPTION
## 개요
* api_client에서 사용하는 base url을 배포한 dcd-api url을 사용하도록 수정합니다.
## 작업내용
* baseUrl을 dcd-api의 url로 수정