### PR TITLE
🔀 :: [#167] - 출력되는 문구 수정

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -80,7 +80,7 @@ var execCmd = &cobra.Command{
 					fmt.Print(message)
 				}
 
-				fmt.Println("")
+				fmt.Println()
 			}
 		} else {
 			workspaceId, err := util.GetWorkspaceId(cmd)

--- a/websocket/websocket_client.go
+++ b/websocket/websocket_client.go
@@ -38,7 +38,7 @@ func SendMessage(conn *websocket.Conn, message string) error {
 
 	select {
 	case <-interrupt:
-		fmt.Println("Interrupt signal received. Closing connection...")
+		fmt.Println("인터럽트 신호를 받았습니다.\n커넥션을 종료합니다...")
 		err := conn.Close()
 		if err != nil {
 			return err


### PR DESCRIPTION
## 개요
* fmt를 사용한 print시 출력되는 문구중 일부를 수정합니다.
## 작업내용
* 웹소켓 커맨드 실행후 개행시 빈문자열 없이 println만 실행하도록 수정
* 웹소켓 클라이언트에서 interrupt 신호를 받았을때 출력되는 문구를 한국어로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

이번 업데이트에서는 사용자 인터페이스에 일부 개선이 이루어졌습니다. 주요 변경 사항은 다음과 같습니다:

- **Style**
	- 인터럽트 신호가 감지될 때 표시되는 안내 메시지가 영어에서 한국어로 변경되어, 한국어 사용자에게 보다 직관적이고 친숙한 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->