### PR TITLE
🔀 :: [#183] - env 삭제 적용

### DIFF
--- a/api/exec/delete_env.go
+++ b/api/exec/delete_env.go
@@ -1,0 +1,45 @@
+package exec
+
+import (
+	"github.com/dolong2/dcd-cli/api"
+	"strings"
+)
+
+func DeleteEnv(key string, workspaceId string, applicationId string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	param := make(map[string]string)
+	param["key"] = key
+
+	_, err = api.SendDelete("/"+workspaceId+"/application/"+applicationId+"/env", header, param)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DeleteEnvWithLabels(key string, workspaceId string, labels []string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	param := make(map[string]string)
+	param["key"] = key
+	param["labels"] = strings.Join(labels, ",")
+
+	_, err = api.SendDelete("/"+workspaceId+"/application/env", header, param)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/exec/delete_global_env.go
+++ b/api/exec/delete_global_env.go
@@ -1,0 +1,24 @@
+package exec
+
+import (
+	"github.com/dolong2/dcd-cli/api"
+)
+
+func DeleteGlobalEnv(key string, workspaceId string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	param := make(map[string]string)
+	param["key"] = key
+
+	_, err = api.SendDelete("/workspace/"+workspaceId+"/env", header, param)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -68,6 +68,18 @@ var deleteCmd = &cobra.Command{
 					return err
 				}
 			}
+		} else if resourceType == "global_env" || resourceType == "ge" {
+			workspaceId, err := util.GetWorkspaceId(cmd)
+			if err != nil {
+				return err
+			}
+
+			envKey := args[1]
+
+			err = exec.DeleteGlobalEnv(envKey, workspaceId)
+			if err != nil {
+				return err
+			}
 		} else {
 			return cmdError.NewCmdError(1, "올바르지 않은 리소스 타입입니다.")
 		}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,7 +27,7 @@ var deleteCmd = &cobra.Command{
 		} else if resourceType == "application" {
 			workspaceId, err := util.GetWorkspaceId(cmd)
 			if err != nil {
-				return err
+				return cmdError.NewCmdError(1, err.Error())
 			}
 
 			var applicationId = args[1]
@@ -38,7 +38,7 @@ var deleteCmd = &cobra.Command{
 		} else if resourceType == "env" {
 			workspaceId, err := util.GetWorkspaceId(cmd)
 			if err != nil {
-				return err
+				return cmdError.NewCmdError(1, err.Error())
 			}
 
 			envKey := args[1]
@@ -65,20 +65,20 @@ var deleteCmd = &cobra.Command{
 
 				err = exec.DeleteEnv(envKey, workspaceId, applicationId)
 				if err != nil {
-					return err
+					return cmdError.NewCmdError(1, err.Error())
 				}
 			}
 		} else if resourceType == "global_env" || resourceType == "ge" {
 			workspaceId, err := util.GetWorkspaceId(cmd)
 			if err != nil {
-				return err
+				return cmdError.NewCmdError(1, err.Error())
 			}
 
 			envKey := args[1]
 
 			err = exec.DeleteGlobalEnv(envKey, workspaceId)
 			if err != nil {
-				return err
+				return cmdError.NewCmdError(1, err.Error())
 			}
 		} else {
 			return cmdError.NewCmdError(1, "올바르지 않은 리소스 타입입니다.")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -35,6 +35,39 @@ var deleteCmd = &cobra.Command{
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
 			}
+		} else if resourceType == "env" {
+			workspaceId, err := util.GetWorkspaceId(cmd)
+			if err != nil {
+				return err
+			}
+
+			envKey := args[1]
+
+			labels, err := cmd.Flags().GetStringArray("label")
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
+
+			if len(labels) > 0 {
+				err := exec.DeleteEnvWithLabels(envKey, workspaceId, labels)
+				if err != nil {
+					return cmdError.NewCmdError(1, err.Error())
+				}
+			} else {
+				applicationId, err := cmd.Flags().GetString("application")
+				if err != nil {
+					return cmdError.NewCmdError(1, err.Error())
+				}
+
+				if applicationId == "" {
+					return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되지 않았습니다.")
+				}
+
+				err = exec.DeleteEnv(envKey, workspaceId, applicationId)
+				if err != nil {
+					return err
+				}
+			}
 		} else {
 			return cmdError.NewCmdError(1, "올바르지 않은 리소스 타입입니다.")
 		}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -47,4 +47,6 @@ func init() {
 	rootCmd.AddCommand(deleteCmd)
 
 	deleteCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
+	deleteCmd.Flags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기 위한 라벨.\nex). -l test-label-1 -l test-label-2")
+	deleteCmd.Flags().StringP("application", "a", "", "애플리케이션 아이디")
 }


### PR DESCRIPTION
## 개요
* 리소스 삭제 커맨드에 env를 적용합니다.
## 작업내용
* 환경변수 제거 메서드 추가
* 리소스 삭제 커맨드에 label, application 플래그 추가
* delete 커맨드에서 환경변수를 지원
* 전역 환경변수 제거 메서드 추가
* delete 커맨드에서 전역 환경변수를 지원

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 환경 변수(`env`) 및 글로벌 환경 변수(`global_env`, `ge`) 삭제 기능이 추가되었습니다.
  - 환경 변수 삭제 시 라벨(`label`) 및 애플리케이션 ID(`application`) 플래그 지원이 추가되었습니다.

- **개선 사항**
  - `delete` 명령어에 라벨 및 애플리케이션 ID 플래그가 추가되어 보다 유연한 삭제가 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->