### PR TITLE
🔀 :: [#185] - 명령어에서 사용하는 출력 메서드 수정

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/dolong2/dcd-cli/cmd/util"
@@ -43,7 +42,7 @@ var execCmd = &cobra.Command{
 			// 사용자 입력을 기다리며 메시지를 서버로 전송
 			reader := bufio.NewReader(os.Stdin)
 			for {
-				fmt.Print(workingDir + " > ")
+				cmd.Print(workingDir + " > ")
 				input, _, _ := reader.ReadLine() // 사용자 입력 받기
 
 				// 인터럽트 신호 처리 (Ctrl+C)
@@ -76,10 +75,10 @@ var execCmd = &cobra.Command{
 						break
 					}
 
-					fmt.Print(message)
+					cmd.Print(message)
 				}
 
-				fmt.Println()
+				cmd.Println()
 			}
 		} else {
 			workspaceId, err := util.GetWorkspaceId(cmd)
@@ -98,7 +97,7 @@ var execCmd = &cobra.Command{
 			}
 
 			for _, result := range cmdResult {
-				fmt.Println(result)
+				cmd.Println(result)
 			}
 		}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/spf13/cobra"
@@ -22,9 +21,9 @@ var loginCmd = &cobra.Command{
 		}
 		password := ""
 		if existsPassword {
-			fmt.Print("Enter password: ")
+			cmd.Print("Enter password: ")
 			bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
-			fmt.Println()
+			cmd.Println()
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
 			}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/dolong2/dcd-cli/cmd/util"
@@ -30,7 +29,7 @@ var logsCmd = &cobra.Command{
 		}
 
 		for _, log := range logs {
-			fmt.Println(log)
+			cmd.Println(log)
 		}
 		return nil
 	},


### PR DESCRIPTION
## 개요
* 명령어에서 사용하는 출력 메서드를 Command의 출력 메서드를 사용하도록 수정합니다.
## 작업내용
* exec 커맨드에서 출력 메서드를 Command의 Println 메서드를 사용하도록 수정
* login 커맨드에서 출력 메서드를 Command의 Println 메서드를 사용하도록 수정
* logs 커맨드에서 출력 메서드를 Command의 Println 메서드를 사용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 명령어 출력 시 표준 출력 함수 대신 내장 출력 함수를 사용하도록 변경되었습니다.  
  - 로그인 및 로그 출력 메시지도 동일하게 내장 출력 함수로 일관성 있게 출력됩니다.  
  - 사용자에게 보이는 메시지 형식이나 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->