### PR TITLE
🔀 :: [#187] - 코드 리펙토링

### DIFF
--- a/api/api_client.go
+++ b/api/api_client.go
@@ -96,7 +96,10 @@ func sendHttpReq(method string, targetUrl string, header map[string]string, para
 			return []byte(""), err
 		}
 		errorResponse := apiErrorResponse{}
-		json.Unmarshal(rawErrorResponse, &errorResponse)
+		err = json.Unmarshal(rawErrorResponse, &errorResponse)
+		if err != nil {
+			return []byte(""), err
+		}
 		return []byte(""), httpErr.NewHttpError(errorResponse.Status, errorResponse.Message)
 	}
 

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -70,7 +70,8 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 
 	resourceType := data.Metadata.ResourceType
 
-	if resourceType == "WORKSPACE" {
+	switch resourceType {
+	case "WORKSPACE":
 		var workspace template.WorkspaceTemplate
 		err = unmarshal(content, &workspace)
 		if err != nil {
@@ -99,7 +100,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 		}
 
 		return createWorkspaceResponse.WorkspaceId, nil
-	} else if resourceType == "APPLICATION" {
+	case "APPLICATION":
 		var application template.ApplicationTemplate
 		err := unmarshal(content, &application)
 		if err != nil {
@@ -134,7 +135,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 		}
 
 		return createApplicationResponse.ApplicationId, nil
-	} else if resourceType == "ENV" {
+	case "ENV":
 		var envTemplate template.EnvTemplate
 		err := unmarshal(content, &envTemplate)
 		if err != nil {
@@ -170,7 +171,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 		}
 
 		return "", nil
-	} else if resourceType == "GLOBAL_ENV" || resourceType == "GE" {
+	case "GLOBAL_ENV", "GE":
 		var globalEnvTemplate template.GlobalEnvTemplate
 		err := unmarshal(content, &globalEnvTemplate)
 		if err != nil {
@@ -188,7 +189,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 		}
 
 		return "", nil
-	} else {
+	default:
 		return "", errors.New("지원되지 않는 리소스 타입입니다")
 	}
 }

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -90,7 +90,9 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 	}
 
 	resourceType := data.Metadata.ResourceType
-	if resourceType == "WORKSPACE" {
+
+	switch resourceType {
+	case "WORKSPACE":
 		var workspace template.WorkspaceTemplate
 		err = unmarshal(content, &workspace)
 		if err != nil {
@@ -111,7 +113,7 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 		if err != nil {
 			return err
 		}
-	} else if resourceType == "APPLICATION" {
+	case "APPLICATION":
 		workspaceId, err := getWorkspaceId()
 		if err != nil {
 			return err
@@ -132,7 +134,7 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 		if err != nil {
 			return err
 		}
-	} else {
+	default:
 		return errors.New("지원되지 않는 리소스 타입입니다")
 	}
 

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -50,7 +50,7 @@ getTokenInfo:
 		}
 		goto getTokenInfo
 	} else if now.After(refreshTokenExp) {
-		return "", errors.New("login info is expired.\nplease retry login.")
+		return "", errors.New("로그인 정보가 만료되었습니다.\n다시 로그인해주세요.")
 	}
 
 	tokenInfo := tokenResponse{


### PR DESCRIPTION
## 개요
* 여러 부분에서 코드 리펙토링을 진행합니다.
## 작업내용
* create에서 리소스 타입을 판단하는 로직을 switch 문으로 수정
* update에서 리소스타입을 판단하는 로직을 switch 문으로 수정
* 엑세스 토큰을 가쟈올때 토큰 만료시 발생하는 에러 메시지 수정
* sendHttpReq 메서드에서 Json 언마셀시 에러 핸들링 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - HTTP 오류 응답 처리 시, 오류 응답 본문이 잘못된 경우를 보다 견고하게 처리하도록 개선되었습니다.

- **리팩터**
  - 여러 리소스 타입을 처리하는 조건문이 switch문으로 변경되어 코드 가독성이 향상되었습니다.

- **스타일**
  - 로그인 만료 오류 메시지가 한글로 변경되었습니다: "로그인 정보가 만료되었습니다.\n다시 로그인해주세요."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->