### PR TITLE
🔀 :: [#195] - 로그아웃 커맨드 추가

### DIFF
--- a/api/exec/logout.go
+++ b/api/exec/logout.go
@@ -1,0 +1,19 @@
+package exec
+
+import "github.com/dolong2/dcd-cli/api"
+
+func Logout() error {
+	header := make(map[string]string)
+	token, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + token
+
+	_, err = api.SendDelete("/auth", header, map[string]string{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/spf13/cobra"
+)
+
+// logoutCmd represents the logout command
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "DCD에서 로그아웃하는 커맨드",
+	Long:  `로그인되어있는 정보를 로그아웃시키는 커맨드입니다.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := exec.Logout()
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(logoutCmd)
+}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -9,7 +9,7 @@ import (
 var profileCmd = &cobra.Command{
 	Use:   "profile",
 	Short: "현재 프로필 조회",
-	Long:  `로그인된 유저 정보의 프로필을 조회합니다.`,
+	Long:  `로그인된 유저 정보의 프로필을 트리 구조로 출력하는 커맨드 입니다.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		profile, err := exec.GetProfile()
 		if err != nil {


### PR DESCRIPTION
## 개요
* 로그아웃 커맨드를 추가합니다.
## 작업내용
* profile 커맨드의 Long 설명 수정
* 로그아웃 메서드 추가
* 로그아웃 커맨드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 DCD 시스템에서 로그아웃할 수 있는 명령어가 추가되었습니다.

- **문서**
  - 프로필 명령어의 설명이 '트리 구조로 출력'됨을 명확히 안내하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->