### PR TITLE
🔀 :: [#201] - API 응답값 핸들링 로직 수정

### DIFF
--- a/api/api_client.go
+++ b/api/api_client.go
@@ -95,6 +95,9 @@ func sendHttpReq(method string, targetUrl string, header map[string]string, para
 		if err != nil {
 			return []byte(""), err
 		}
+		if len(rawErrorResponse) == 0 {
+			return []byte(""), httpErr.NewHttpError(httpResponse.StatusCode, "알 수 없는 에러")
+		}
 		errorResponse := apiErrorResponse{}
 		err = json.Unmarshal(rawErrorResponse, &errorResponse)
 		if err != nil {


### PR DESCRIPTION
## 개요
* API의 에러 응답값을 핸들링하는 로직을 수정합니다.
## 작업내용
* 실패 응답의 본문이 비어있을때도 정상적으로 핸들링되도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?