### PR TITLE
🔀 :: [#208] - 도메인 조회 커맨드 추가

### DIFF
--- a/api/exec/get_domain.go
+++ b/api/exec/get_domain.go
@@ -1,0 +1,29 @@
+package exec
+
+import (
+	"encoding/json"
+	"github.com/dolong2/dcd-cli/api"
+	"github.com/dolong2/dcd-cli/api/exec/response"
+)
+
+func GetDomains(workspaceId string) (*response.DomainListResponse, error) {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	result, err := api.SendGet("/"+workspaceId+"/domain", header, map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+
+	var domainListResponse response.DomainListResponse
+	err = json.Unmarshal(result, &domainListResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domainListResponse, nil
+}

--- a/api/exec/response/application.go
+++ b/api/exec/response/application.go
@@ -22,3 +22,9 @@ type ApplicationResponse struct {
 type ApplicationListResponse struct {
 	Applications []ApplicationResponse `json:"list"`
 }
+
+type applicationSimpleResponse struct {
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}

--- a/api/exec/response/domain.go
+++ b/api/exec/response/domain.go
@@ -3,3 +3,14 @@ package response
 type CreateDomainResponse struct {
 	DomainId string `json:"domainId"`
 }
+
+type DomainResponse struct {
+	DomainId    string                     `json:"id"`
+	Name        string                     `json:"name"`
+	Description string                     `json:"description"`
+	Application *applicationSimpleResponse `json:"application"`
+}
+
+type DomainListResponse struct {
+	Domains []DomainResponse `json:"list"`
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -123,6 +123,22 @@ func getApplication(cmd *cobra.Command) error {
 	return nil
 }
 
+func getDomain(cmd *cobra.Command) error {
+	workspaceId, err := util.GetWorkspaceId(cmd)
+	if err != nil {
+		return err
+	}
+
+	domainListResponse, err := exec.GetDomains(workspaceId)
+	if err != nil {
+		return cmdError.NewCmdError(1, err.Error())
+	}
+
+	printDomainList(domainListResponse.Domains)
+
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(getCmd)
 
@@ -261,4 +277,29 @@ func printApplicationTypes() error {
 	table.Render()
 
 	return nil
+}
+
+func printDomainList(domainList []response.DomainResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+
+	table.SetHeader([]string{"ID", "NAME", "Description", "STATUS", "APPLICATION"})
+
+	for _, domain := range domainList {
+
+		var status, applicationName string
+		if domain.Application != nil {
+			status = "CONNECTED"
+			applicationName = domain.Application.Name
+		} else {
+			status = "UNCONNECTED"
+			applicationName = ""
+		}
+
+		row := []string{domain.DomainId, domain.Name, domain.Description, status, applicationName}
+		table.Append(row)
+	}
+
+	table.Render()
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -18,9 +18,10 @@ var getCmd = &cobra.Command{
 	Short: "리소스를 조회하는 커맨드",
 	Long: `이 커맨드는 리소스를 조회하기 위해서 사용됩니다.
 리소스 타입:
-	workspaces - 이 리소스 타입은 여러 애플리케이션을 가지고, 작업구역(네트워크)를 나눌때 사용합니다.
+	workspaces - 이 리소스 타입은 여러 애플리케이션을 가지고, 작업구역을 나눌때 사용합니다.
 	applications - 이 리소스 타입은 특정 라이브러리 혹은 프레임워크가 컨테이너에서 동작하게 하는 리소스 타입입니다.
-	types - 애플리케이션의 타입 종류를 나타내는 리소스 타입입니다.`,
+	types - 애플리케이션의 타입 종류를 나타내는 리소스 타입입니다.
+	domains - 해당 리소스타입은 애플리케이션을 HTTPS로 외부에 공개할때 사용되는 리소스 타입입니다.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmdError.NewCmdError(1, "리소스 타입이 입력되어야 합니다.")
@@ -39,6 +40,11 @@ var getCmd = &cobra.Command{
 			}
 		} else if resourceType == "types" {
 			err := printApplicationTypes()
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
+		} else if resourceType == "domains" {
+			err := getDomain(cmd)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
 			}


### PR DESCRIPTION
## 개요
* `get`명령에서 `resourceType`으로 도메인을 사용할 수 있도록합니다.
## 작업내용
* 애플리케이션 연관 응답 구조체 추가
* 도메인 응답 구조체 추가
* 특정 워크스페이스의 도메인 목록 조회 로직 추가
* 도메인 목록 정보 출력 메서드 추가
* get 커맨드에서 도메인을 지원하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "domains" 리소스 유형을 추가하여, 워크스페이스에 연결된 도메인 목록을 조회하고 표시할 수 있습니다.
  * 도메인 정보가 표 형식으로 ID, 이름, 설명, 상태, 연결된 애플리케이션 정보와 함께 출력됩니다.  
* **Documentation**
  * "domains" 리소스 유형에 대한 설명이 명령어 안내에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->