### PR TITLE
🔀 :: [#214] - 삭제 커맨드에서 도메인 지원

### DIFF
--- a/api/exec/delete_domain.go
+++ b/api/exec/delete_domain.go
@@ -1,0 +1,20 @@
+package exec
+
+import (
+	"github.com/dolong2/dcd-cli/api"
+)
+
+func DeleteDomain(workspaceId string, domainId string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	_, err = api.SendDelete("/"+workspaceId+"/domain/"+domainId, header, map[string]string{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -80,6 +80,17 @@ var deleteCmd = &cobra.Command{
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
 			}
+		} else if resourceType == "domain" {
+			workspaceId, err := util.GetWorkspaceId(cmd)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
+
+			domainId := args[1]
+			err = exec.DeleteDomain(workspaceId, domainId)
+			if err != nil {
+				return cmdError.NewCmdError(1, err.Error())
+			}
 		} else {
 			return cmdError.NewCmdError(1, "올바르지 않은 리소스 타입입니다.")
 		}


### PR DESCRIPTION
## 개요
* 도메인을 삭제하는 커맨드를 추가합니다.
## 작업내용
* 도메인 삭제 요청 메서드 추가
* delete 커맨드에서 도메인을 지원하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 도메인 삭제 기능이 추가되었습니다. 이제 명령어를 통해 특정 워크스페이스의 도메인을 삭제할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->