### PR TITLE
🔀 :: [#207] - ToRequest 메서드의 nil 포인터 역참조 위험성 개선

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -78,12 +78,11 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		err = workspace.ValidateMetadata()
+		createWorkspaceRequest, err := workspace.ToRequest()
 		if err != nil {
 			return "", err
 		}
-
-		request, err := json.Marshal(workspace.ToRequest())
+		request, err := json.Marshal(createWorkspaceRequest)
 		if err != nil {
 			return "", err
 		}
@@ -107,12 +106,11 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		err = application.ValidateMetadata()
+		createApplicationRequest, err := application.ToRequest()
 		if err != nil {
 			return "", err
 		}
-
-		request, err := json.Marshal(application.ToRequest())
+		request, err := json.Marshal(createApplicationRequest)
 		if err != nil {
 			return "", err
 		}
@@ -196,12 +194,11 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		err = domainTemplate.ValidateMetadata()
+		createDomainRequest, err := domainTemplate.ToRequest()
 		if err != nil {
 			return "", err
 		}
-
-		request, err := json.Marshal(domainTemplate.ToRequest())
+		request, err := json.Marshal(createDomainRequest)
 		if err != nil {
 			return "", err
 		}

--- a/api/exec/template/application.go
+++ b/api/exec/template/application.go
@@ -10,7 +10,7 @@ type ApplicationTemplate struct {
 	Spec     applicationSpecTemplate `json:"spec" yaml:"spec"`
 }
 
-func (template ApplicationTemplate) ValidateMetadata() error {
+func (template ApplicationTemplate) validateMetadata() error {
 	if template.Metadata.Name == nil || template.Metadata.Description == nil {
 		return errors.New("애플리케이션 메타데이터 정보가 올바르지 않습니다")
 	}
@@ -26,8 +26,13 @@ type applicationSpecTemplate struct {
 	Labels          []string `json:"labels" yaml:"labels"`
 }
 
-func (template ApplicationTemplate) ToRequest() request.ApplicationRequest {
-	return request.ApplicationRequest{
+func (template ApplicationTemplate) ToRequest() (*request.ApplicationRequest, error) {
+	err := template.validateMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	return &request.ApplicationRequest{
 		Name:            *template.Metadata.Name,
 		Description:     *template.Metadata.Description,
 		GithubUrl:       template.Spec.GithubUrl,
@@ -35,5 +40,5 @@ func (template ApplicationTemplate) ToRequest() request.ApplicationRequest {
 		Port:            template.Spec.Port,
 		Version:         template.Spec.Version,
 		Labels:          template.Spec.Labels,
-	}
+	}, nil
 }

--- a/api/exec/template/domain.go
+++ b/api/exec/template/domain.go
@@ -9,14 +9,19 @@ type DomainTemplate struct {
 	Metadata metaData `json:"metadata" yaml:"metadata"`
 }
 
-func (template DomainTemplate) ToRequest() request.CreateDomainRequest {
-	return request.CreateDomainRequest{
+func (template DomainTemplate) ToRequest() (*request.CreateDomainRequest, error) {
+	err := template.validateMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	return &request.CreateDomainRequest{
 		Name:        *template.Metadata.Name,
 		Description: *template.Metadata.Description,
-	}
+	}, nil
 }
 
-func (template DomainTemplate) ValidateMetadata() error {
+func (template DomainTemplate) validateMetadata() error {
 	if template.Metadata.Name == nil || template.Metadata.Description == nil {
 		return errors.New("도메인 메타데이터 정보가 올바르지 않습니다")
 	}

--- a/api/exec/template/workspace.go
+++ b/api/exec/template/workspace.go
@@ -9,7 +9,7 @@ type WorkspaceTemplate struct {
 	Metadata metaData `json:"metadata" yaml:"metadata"`
 }
 
-func (template WorkspaceTemplate) ValidateMetadata() error {
+func (template WorkspaceTemplate) validateMetadata() error {
 	if template.Metadata.Name == nil || template.Metadata.Description == nil {
 		return errors.New("워크스페이스 메타데이터 정보가 올바르지 않습니다")
 	}
@@ -17,9 +17,14 @@ func (template WorkspaceTemplate) ValidateMetadata() error {
 	return nil
 }
 
-func (template WorkspaceTemplate) ToRequest() request.WorkspaceRequest {
-	return request.WorkspaceRequest{
+func (template WorkspaceTemplate) ToRequest() (*request.WorkspaceRequest, error) {
+	err := template.validateMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	return &request.WorkspaceRequest{
 		Name:        *template.Metadata.Name,
 		Description: *template.Metadata.Description,
-	}
+	}, nil
 }

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -125,6 +125,9 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 		}
 
 		updateApplicationRequest, err := application.ToRequest()
+		if err != nil {
+			return err
+		}
 		request, err := json.Marshal(updateApplicationRequest)
 		if err != nil {
 			return err

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -99,12 +99,11 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 			return err
 		}
 
-		err = workspace.ValidateMetadata()
+		updateWorkspaceRequest, err := workspace.ToRequest()
 		if err != nil {
 			return err
 		}
-
-		request, err := json.Marshal(workspace.ToRequest())
+		request, err := json.Marshal(updateWorkspaceRequest)
 		if err != nil {
 			return err
 		}
@@ -125,7 +124,8 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 			return err
 		}
 
-		request, err := json.Marshal(application.ToRequest())
+		updateApplicationRequest, err := application.ToRequest()
+		request, err := json.Marshal(updateApplicationRequest)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## 개요
* ToRequest 메서드의 nil 포인터 역참조 위험성 개선
## 작업내용
* 템플릿을 Request 객체로 래핑하는 메서드에서 validateMetadata 메서드를 호출하도록 리펙토링
* create 메서드에서 템플릿을 request로 래핑하는 로직 수정
* update 메서드에서 템플릿을 request로 래핑하는 로직 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 워크스페이스, 애플리케이션, 도메인 템플릿 처리 시 중복된 요청 변환 및 검증 호출을 제거하여 오류 처리를 명확하게 개선했습니다.

* **리팩터**
  * 내부 요청 생성 및 검증 로직을 간소화하여 안정성과 코드 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->