### PR TITLE
🔀 :: [#225] - 변경된 스펙에 맞게 환경변수 삭제 커맨드 수정

### DIFF
--- a/api/exec/delete_env.go
+++ b/api/exec/delete_env.go
@@ -2,10 +2,9 @@ package exec
 
 import (
 	"github.com/dolong2/dcd-cli/api"
-	"strings"
 )
 
-func DeleteEnv(key string, workspaceId string, applicationId string) error {
+func DeleteEnv(workspaceId string, envId string) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -13,10 +12,7 @@ func DeleteEnv(key string, workspaceId string, applicationId string) error {
 	}
 	header["Authorization"] = "Bearer " + accessToken
 
-	param := make(map[string]string)
-	param["key"] = key
-
-	_, err = api.SendDelete("/"+workspaceId+"/application/"+applicationId+"/env", header, param)
+	_, err = api.SendDelete("/"+workspaceId+"/env/"+envId, header, map[string]string{})
 	if err != nil {
 		return err
 	}

--- a/api/exec/delete_env.go
+++ b/api/exec/delete_env.go
@@ -23,23 +23,3 @@ func DeleteEnv(key string, workspaceId string, applicationId string) error {
 
 	return nil
 }
-
-func DeleteEnvWithLabels(key string, workspaceId string, labels []string) error {
-	header := make(map[string]string)
-	accessToken, err := GetAccessToken()
-	if err != nil {
-		return err
-	}
-	header["Authorization"] = "Bearer " + accessToken
-
-	param := make(map[string]string)
-	param["key"] = key
-	param["labels"] = strings.Join(labels, ",")
-
-	_, err = api.SendDelete("/"+workspaceId+"/application/env", header, param)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -47,32 +47,11 @@ var deleteCmd = &cobra.Command{
 				return cmdError.NewCmdError(1, err.Error())
 			}
 
-			envKey := args[1]
+			envId := args[1]
 
-			labels, err := cmd.Flags().GetStringArray("label")
+			err = exec.DeleteEnv(workspaceId, envId)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
-			}
-
-			if len(labels) > 0 {
-				err := exec.DeleteEnvWithLabels(envKey, workspaceId, labels)
-				if err != nil {
-					return cmdError.NewCmdError(1, err.Error())
-				}
-			} else {
-				applicationId, err := cmd.Flags().GetString("application")
-				if err != nil {
-					return cmdError.NewCmdError(1, err.Error())
-				}
-
-				if applicationId == "" {
-					return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되지 않았습니다.")
-				}
-
-				err = exec.DeleteEnv(envKey, workspaceId, applicationId)
-				if err != nil {
-					return cmdError.NewCmdError(1, err.Error())
-				}
 			}
 		case resourceType.IsEqual(resource.GlobalEnv):
 			workspaceId, err := util.GetWorkspaceId(cmd)


### PR DESCRIPTION
## 개요
* 변경된 스펙에 맞게끔 환경변수 삭제 커맨드를 수정합니다.
## 작업내용
* 라벨을 통한 환경변수 제거 메서드 삭제
* 환경변수 삭제 스펙 변경에 따른 환경변수 삭제 메서드 수정
* 환경변수 삭제 커맨드 스펙 변경
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [x] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 환경 삭제 흐름을 워크스페이스 범위에서 envId로 직접 삭제하도록 단순화했습니다.
  - CLI에서 라벨 기반 삭제와 애플리케이션 기반 삭제 옵션을 제거했습니다.
  - 환경 삭제 명령은 이제 workspaceId와 envId를 요구하며, 단일 경로로 처리됩니다.
  - 워크스페이스, 애플리케이션, 전역 환경, 도메인 등 기타 리소스 삭제 동작은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->