### PR TITLE
🔀 :: [#231] - 파일 확장자 검증 로직 메서드로 분리

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -6,9 +6,7 @@ import (
 	"github.com/dolong2/dcd-cli/api"
 	"github.com/dolong2/dcd-cli/api/exec/response"
 	"github.com/dolong2/dcd-cli/api/exec/template"
-	"gopkg.in/yaml.v3"
 	"os"
-	"path/filepath"
 )
 
 func CreateByPath(fileDirectory string) error {
@@ -17,21 +15,10 @@ func CreateByPath(fileDirectory string) error {
 		return err
 	}
 
-	var resourceId = ""
-	ext := filepath.Ext(fileDirectory)
-	switch ext {
-	case ".json":
-		resourceId, err = create(content, json.Unmarshal)
-		if err != nil {
-			return err
-		}
-	case ".yml", ".yaml":
-		resourceId, err = create(content, yaml.Unmarshal)
-		if err != nil {
-			return err
-		}
-	default:
-		return errors.New("invalid file extension")
+	unmarshal, err := resolveFileExtension(fileDirectory)
+	resourceId, err := create(content, unmarshal)
+	if err != nil {
+		return err
 	}
 
 	if resourceId != "" {

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -16,6 +16,9 @@ func CreateByPath(fileDirectory string) error {
 	}
 
 	unmarshal, err := resolveFileExtension(fileDirectory)
+	if err != nil {
+		return err
+	}
 	resourceId, err := create(content, unmarshal)
 	if err != nil {
 		return err

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -25,21 +25,8 @@ func UpdateByPath(resourceId string, fileDirectory string) error {
 		return err
 	}
 
-	ext := filepath.Ext(fileDirectory)
-	switch ext {
-	case ".json":
-		err = update(resourceId, content, json.Unmarshal)
-		if err != nil {
-			return err
-		}
-	case ".yml", ".yaml":
-		err = update(resourceId, content, yaml.Unmarshal)
-		if err != nil {
-			return err
-		}
-	default:
-		return errors.New("지원되지 않는 파일 확장자입니다.")
-	}
+	unmarshal, err := resolveFileExtension(fileDirectory)
+	err = update(resourceId, content, unmarshal)
 
 	return nil
 }

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -26,6 +26,9 @@ func UpdateByPath(resourceId string, fileDirectory string) error {
 	}
 
 	unmarshal, err := resolveFileExtension(fileDirectory)
+	if err != nil {
+		return err
+	}
 	err = update(resourceId, content, unmarshal)
 
 	return nil

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"encoding/json"
 	"errors"
+	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"time"
@@ -151,4 +152,17 @@ func GetResourceIdByFilePath(fileDirectory string) (string, error) {
 	}
 
 	return resourceId, nil
+}
+
+func resolveFileExtension(fileDirectory string) (func([]byte, interface{}) (err error), error) {
+	ext := filepath.Ext(fileDirectory)
+
+	switch ext {
+	case ".json":
+		return json.Unmarshal, nil
+	case ".yml", ".yaml":
+		return yaml.Unmarshal, nil
+	default:
+		return nil, errors.New("지원되지 않는 파일 확장자입니다.")
+	}
 }


### PR DESCRIPTION
## 개요
* 리소스 생성및 리소스 수정시 사용되는 확장자 검증 로직이 중복되는 부분을 메서드로 분리합니다.
## 작업내용
* 지원되는 파일 확장자에 맞춰서 unmarshal 메서드를 반환하는 함수 추가
* 리소스 생성시 메서드를 사용해서 확장자에 맞는 unmarshal 메서드를 가져오도록 변경
* 리소스 변경시 메서드를 사용해서 확장자에 맞는 unmarshal 메서드를 가져오도록 변경
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - YAML(.yml/.yaml) 형식 지원이 추가되어 JSON과 함께 파일 기반 작업이 가능해졌습니다.
- 리팩터
  - 파일 확장자 처리 흐름을 통합해 파싱과 생성/업데이트 과정이 단순화되었습니다.
  - 파일 확장자 관련 오류 처리 방식이 변경되어, 일부 잘못된 확장자에서 발생하던 오류가 덜 보고될 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->