### PR TITLE
🔀 :: [#235] - 유저 가입 커맨드 추가

### DIFF
--- a/api/exec/certificate_auth_code.go
+++ b/api/exec/certificate_auth_code.go
@@ -1,0 +1,21 @@
+package exec
+
+import (
+	"encoding/json"
+	"github.com/dolong2/dcd-cli/api"
+	"github.com/dolong2/dcd-cli/api/exec/request"
+)
+
+func CertificateAuthCode(email string, code string) error {
+	certificateAuthCodeRequest, err := json.Marshal(request.CertificateAuthCodeRequest{Email: email, Code: code})
+	if err != nil {
+		return err
+	}
+
+	_, err = api.SendPost("/auth/email/certificate", map[string]string{}, map[string]string{}, certificateAuthCodeRequest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/exec/request/auth.go
+++ b/api/exec/request/auth.go
@@ -1,0 +1,17 @@
+package request
+
+type SendAuthCodeRequest struct {
+	Email string `json:"email"`
+	Usage string `json:"usage"`
+}
+
+type CertificateAuthCodeRequest struct {
+	Email string `json:"email"`
+	Code  string `json:"code"`
+}
+
+type SignUpRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Name     string `json:"name"`
+}

--- a/api/exec/send_auth_code.go
+++ b/api/exec/send_auth_code.go
@@ -1,0 +1,22 @@
+package exec
+
+import (
+	"encoding/json"
+	"github.com/dolong2/dcd-cli/api"
+	"github.com/dolong2/dcd-cli/api/exec/request"
+)
+
+func SendAuthCode(email string, usage string) error {
+	sendAuthCodeRequest := request.SendAuthCodeRequest{Email: email, Usage: usage}
+	rawSendAuthCodeRequest, err := json.Marshal(sendAuthCodeRequest)
+	if err != nil {
+		return err
+	}
+
+	_, err = api.SendPost("/auth/email", map[string]string{}, map[string]string{}, rawSendAuthCodeRequest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/exec/sign_up.go
+++ b/api/exec/sign_up.go
@@ -1,0 +1,22 @@
+package exec
+
+import (
+	"encoding/json"
+	"github.com/dolong2/dcd-cli/api"
+	"github.com/dolong2/dcd-cli/api/exec/request"
+)
+
+func SignUp(email string, password string, name string) error {
+	signUpRequest, err := json.Marshal(request.SignUpRequest{Email: email, Password: password, Name: name})
+
+	if err != nil {
+		return err
+	}
+
+	_, err = api.SendPost("/auth/signup", map[string]string{}, map[string]string{}, signUpRequest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"os"
+)
+
+// registerCmd represents the register command
+var registerCmd = &cobra.Command{
+	Use:   "register <email> <name>",
+	Short: "유저 가입 커맨드",
+	Long:  `유저 회원가입을 진행하는 커맨드 입니다.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return cmdError.NewCmdError(1, "이메일과 이름이 입력되지 않음")
+		}
+
+		email := args[0]
+		name := args[1]
+		if email == "" || name == "" {
+			return cmdError.NewCmdError(1, "이메일과 이름이 입력되지 않음")
+		}
+
+		err := exec.SendAuthCode(email, "SIGNUP")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+	enterCode:
+		cmd.Print("인증 코드: ")
+		byteCode, err := term.ReadPassword(int(os.Stdin.Fd()))
+		cmd.Println()
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		authCode := string(byteCode)
+		err = exec.CertificateAuthCode(email, authCode)
+		if err != nil {
+			cmd.Println(err.Error())
+			goto enterCode
+		}
+
+		cmd.Print("패스워드: ")
+		bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
+		cmd.Println()
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		password := string(bytePassword)
+
+		err = exec.SignUp(email, password, name)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(registerCmd)
+}


### PR DESCRIPTION
## 개요
* 유저 가입 커맨드를 추가합니다.
## 작업내용
* 회원가입시 필요한 인증 요청 구조체 추가
* 이메일 인증 코드 전송 메서드 추가
* 이메일 인증 코드 검증 메서드 추가
* 회원가입 메서드 추가
* 회원가입 커맨드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 신규 회원가입 명령어 추가: register <email> <name>
  * 이메일 인증코드 발송 → 코드 확인 → 비밀번호 설정까지 터미널에서 단계별 진행
  * 잘못된 인증코드 재입력 지원 및 코드/비밀번호 숨김 입력으로 보안성 향상
  * 명확한 오류 메시지와 종료 코드 제공으로 스크립트/CI 연동 용이

<!-- end of auto-generated comment: release notes by coderabbit.ai -->