### PR TITLE
🔀 :: [#237] - 회원가입 커맨드 플로우 수정

### DIFF
--- a/cmd/register.go
+++ b/cmd/register.go
@@ -29,13 +29,11 @@ var registerCmd = &cobra.Command{
 
 	enterCode:
 		cmd.Print("인증 코드: ")
-		byteCode, err := term.ReadPassword(int(os.Stdin.Fd()))
-		cmd.Println()
+		var authCode string
+		_, err = fmt.Scanf("%s", &authCode)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
-
-		authCode := string(byteCode)
 		err = exec.CertificateAuthCode(email, authCode)
 		if err != nil {
 			cmd.Println(err.Error())


### PR DESCRIPTION
## 개요
* 회원가입 커맨드를 리펙토링합니다.
## 작업내용
* 회원가입 커맨드에서 이름과 이메일을 커맨드 실행후 입력받도록 수정
* 인증코드 입력시 fmt 입력함수로 받도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 회원가입이 대화형 흐름으로 변경되었습니다: 이메일 입력 → 인증코드 전송/검증 → 이름·비밀번호 입력.
  - 인증코드 검증 실패 시 재입력할 수 있습니다.
- Documentation
  - 명령어 사용법이 “register <email> <name>”에서 “register”로 단순화되었습니다.
  - 입력 안내 및 오류 메시지가 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->