### PR TITLE
🔀 :: [#243] - 볼륨 마운트 커맨드 추가

### DIFF
--- a/api/exec/mount_volume.go
+++ b/api/exec/mount_volume.go
@@ -1,0 +1,31 @@
+package exec
+
+import (
+	"encoding/json"
+	"github.com/dolong2/dcd-cli/api"
+	"github.com/dolong2/dcd-cli/api/exec/request"
+)
+
+func MountVolume(workspaceId string, volumeId string, targetApplicationId string, mountPath string, readOnly bool) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	param := make(map[string]string)
+	param["applicationId"] = targetApplicationId
+
+	mountVolumeRequest := request.MountVolumeRequest{
+		MountPath: mountPath,
+		ReadOnly:  readOnly,
+	}
+	requestBody, err := json.Marshal(mountVolumeRequest)
+	if err != nil {
+		return err
+	}
+
+	_, err = api.SendPost("/"+workspaceId+"/volume/"+volumeId+"/mount", header, param, requestBody)
+	return err
+}

--- a/api/exec/request/volume.go
+++ b/api/exec/request/volume.go
@@ -4,3 +4,8 @@ type VolumeRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }
+
+type MountVolumeRequest struct {
+	MountPath string `json:"mountPath"`
+	ReadOnly  bool   `json:"readOnly"`
+}

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
+	"github.com/spf13/cobra"
+)
+
+// mountCmd represents the mount command
+var mountCmd = &cobra.Command{
+	Use:   "mount <volumeId> <mountPath>",
+	Short: "볼륨을 애플리케이션에 마운트할때 사용하는 커맨드입니다.",
+	Long:  `존재하는 볼륨을 애플리케이션에 마운트합니다.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId(cmd)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		if len(args) != 2 {
+			return cmdError.NewCmdError(1, "볼륨 아이디 혹은 마운트 경로가 입력되지 않았습니다.")
+		}
+		volumeId := args[0]
+		if volumeId == "" {
+			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되지 않았습니다.")
+		}
+		mountPath := args[1]
+		if mountPath == "" {
+			return cmdError.NewCmdError(1, "마운트 경로가 입력되지 않았습니다.")
+		}
+
+		applicationId, err := cmd.Flags().GetString("application")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+		if applicationId == "" {
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되지 않았습니다.")
+		}
+
+		readOnly, err := cmd.Flags().GetBool("readOnly")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		err = exec.MountVolume(workspaceId, volumeId, applicationId, mountPath, readOnly)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(mountCmd)
+
+	mountCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
+	mountCmd.Flags().StringP("application", "a", "", "볼륨을 마운트할 애플리케이션 아이디")
+	mountCmd.Flags().BoolP("readOnly", "", false, "읽기 전용으로 마운트")
+}


### PR DESCRIPTION
## 개요
* 볼륨 마운트 커맨드를 추가합니다.
## 작업내용
* 볼륨 마운트 요청 구조체 추가
* 볼륨 마운트 요청 함수 추가
* 볼륨 마운트 커맨드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - CLI에 볼륨 마운트 명령 추가: mount <volumeId> <mountPath>로 애플리케이션에 볼륨을 연결할 수 있습니다.
  - 옵션 지원: --workspace(-w), --application(-a, 필수), --readOnly(읽기 전용 마운트).
  - 인자/옵션 유효성 검사 강화: 누락·빈 값·형식 오류 시 명확한 한글 안내 메시지 제공.
  - 성공/실패 결과를 즉시 피드백하여 마운트 상태를 빠르게 확인 가능.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->