### PR TITLE
🔀 :: [#245] - 마운트 해제 커맨드 추가

### DIFF
--- a/api/exec/unmount_volume.go
+++ b/api/exec/unmount_volume.go
@@ -1,0 +1,20 @@
+package exec
+
+import (
+	"github.com/dolong2/dcd-cli/api"
+)
+
+func UnmountVolume(workspaceId string, volumeId string, targetApplicationId string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	param := make(map[string]string)
+	param["applicationId"] = targetApplicationId
+
+	_, err = api.SendDelete("/"+workspaceId+"/volume/"+volumeId+"/mount", header, param)
+	return err
+}

--- a/cmd/unmount.go
+++ b/cmd/unmount.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
+
+	"github.com/spf13/cobra"
+)
+
+// unmountCmd represents the unmount command
+var unmountCmd = &cobra.Command{
+	Use:   "unmount <volumeId>",
+	Short: "볼륨 마운트를 해제하는 커맨드입니다.",
+	Long:  `특정 애플리케이션의 볼륨 마운트를 해제합니다.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workspaceId, err := util.GetWorkspaceId(cmd)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		if len(args) != 1 {
+			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되지 않았습니다.")
+		}
+		volumeId := args[0]
+		if volumeId == "" {
+			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되지 않았습니다.")
+		}
+
+		applicationId, err := cmd.Flags().GetString("application")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+		if applicationId == "" {
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되지 않았습니다.")
+		}
+
+		err = exec.UnmountVolume(workspaceId, volumeId, applicationId)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(unmountCmd)
+
+	unmountCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
+	unmountCmd.Flags().StringP("application", "a", "", "볼륨을 마운트할 애플리케이션 아이디")
+}


### PR DESCRIPTION
## 개요
* 볼륨을 애플리케이션에서 마운트를 해제하는 커맨드를 추가합니다.
## 작업내용
* 볼륨 마운트 해제 요청 메서드 추가
* 볼륨 마운트 해제 커맨드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - CLI에 unmount 명령이 추가되어 워크스페이스 내 특정 애플리케이션에서 볼륨 연결을 해제할 수 있습니다.
  - 사용법: unmount <volumeId> -a <applicationId> [-w <workspaceId>]
  - 옵션: --application/-a (애플리케이션 아이디), --workspace/-w (워크스페이스 아이디). 한국어 설명과 도움말을 제공합니다.
  - 인자/옵션 누락 또는 빈 값 입력 시 명확한 오류 메시지를 반환합니다.
  - 성공 시 추가 출력 없이 정상 종료됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->