### PR TITLE
🔀 :: [#247] - CmdError 재래핑 컨벤션 통일

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -18,7 +18,7 @@ var connectCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			return err
+			return cmdError.NewCmdError(1, err.Error())
 		}
 
 		if len(args) != 2 {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -15,7 +15,7 @@ var deployCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			return err
+			return cmdError.NewCmdError(1, err.Error())
 		}
 
 		labels, err := cmd.Flags().GetStringArray("label")

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -18,7 +18,7 @@ var disconnectCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			return err
+			return cmdError.NewCmdError(1, err.Error())
 		}
 
 		if len(args) == 0 {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -83,7 +83,7 @@ var execCmd = &cobra.Command{
 		} else {
 			workspaceId, err := util.GetWorkspaceId(cmd)
 			if err != nil {
-				return err
+				return cmdError.NewCmdError(1, err.Error())
 			}
 
 			command, err := cmd.Flags().GetString("command")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -105,7 +105,7 @@ func getWorkspace(cmd *cobra.Command) error {
 func getApplication(cmd *cobra.Command) error {
 	workspaceId, err := util.GetWorkspaceId(cmd)
 	if err != nil {
-		return err
+		return cmdError.NewCmdError(1, err.Error())
 	}
 
 	applicationId, err := cmd.Flags().GetString("id")
@@ -150,7 +150,7 @@ func getApplication(cmd *cobra.Command) error {
 func getDomain(cmd *cobra.Command) error {
 	workspaceId, err := util.GetWorkspaceId(cmd)
 	if err != nil {
-		return err
+		return cmdError.NewCmdError(1, err.Error())
 	}
 
 	domainListResponse, err := exec.GetDomains(workspaceId)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -16,7 +16,7 @@ var logsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			return err
+			return cmdError.NewCmdError(1, err.Error())
 		}
 
 		if len(args) == 0 {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,7 +16,7 @@ var runCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			return err
+			return cmdError.NewCmdError(1, err.Error())
 		}
 
 		labels, err := cmd.Flags().GetStringArray("label")

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -16,7 +16,7 @@ var stopCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		workspaceId, err := util.GetWorkspaceId(cmd)
 		if err != nil {
-			return err
+			return cmdError.NewCmdError(1, err.Error())
 		}
 
 		labels, err := cmd.Flags().GetStringArray("label")

--- a/cmd/util/get_workspace_info.go
+++ b/cmd/util/get_workspace_info.go
@@ -3,7 +3,6 @@ package util
 import (
 	"encoding/json"
 	"errors"
-	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -13,7 +12,7 @@ func GetWorkspaceId(cmd *cobra.Command) (string, error) {
 	if err != nil || workspaceId == "" {
 		workspaceId, err = getWorkspaceInfo()
 		if err != nil {
-			return "", cmdError.NewCmdError(1, "워크스페이스 아이디가 입력되어야합니다.")
+			return "", errors.New("워크스페이스 아이디가 입력되어야합니다.")
 		}
 	}
 	return workspaceId, nil


### PR DESCRIPTION
## 개요
* CmdError 재래핑 컨벤션을 통일합니다.
  * `util.GetWorkspaceId` 호출후 에러 처리 로직의  컨벤션이 통일되어 있지않음
## 작업내용
* 워크스페이스 아이디 조회시 무조건 error만 반환하도록 수정
* GetWorkspaceId 메서드 사용시 에러 처리할때 무조건 cmdError로 래핑하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* GetWorkspaceId 메서드 자체에서도 error와 cmdError가 혼용되서 사용되고 있었기 때문에 error만 반환하도록 수정하고, 호출후 에러 처리시 cmdError로 래핑하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 워크스페이스 ID 조회 실패 시 모든 명령(connect, deploy, disconnect, exec, get, logs, run, stop)에서 일관된 오류 형식과 메시지, 종료 코드를 반환하도록 개선했습니다.
  - 오류 메시지 가독성과 예측 가능성이 향상되어 문제 원인 파악이 더 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->