### PR TITLE
🔀 :: [#251] - 웹소켓 Url을 외부에서 주입받도록 수정

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ fi
 cd "$TEMP_DIR" || exit 1
 
 echo "Go 빌드 중..."
-go build -ldflags="-X github.com/dolong2/dcd-cli/api.baseUrl=https://dcd-api.dolong2.co.kr" -o "$BINARY_NAME"
+go build -ldflags="-X github.com/dolong2/dcd-cli/api.baseUrl=https://dcd-api.dolong2.co.kr -X github.com/dolong2/dcd-cli/websocket.baseUrl=wss://dcd-api.dolong2.co.kr" -o "$BINARY_NAME"
 
 if [ ! -f "$BINARY_NAME" ]; then
   echo "빌드 실패"

--- a/websocket/websocket_client.go
+++ b/websocket/websocket_client.go
@@ -9,8 +9,10 @@ import (
 	"os/signal"
 )
 
+var baseUrl string
+
 func Connect(applicationId string) (*websocket.Conn, error) {
-	serverUrl := "wss://dcd-api.dolong2.co.kr/application/exec?applicationId=" + applicationId
+	serverUrl := baseUrl + "/application/exec?applicationId=" + applicationId
 
 	header := http.Header{}
 	accessToken, err := exec.GetAccessToken()


### PR DESCRIPTION
## 개요
* 각 환경에서 유연하게 사용할 수 있도록 수정합니다 
## 작업내용
* websocket의 도메인 부분을 baseUrl 변수로 치환하도록 수정
* install 스크립트에서 websocket baseUrl을 초기화하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 빌드 구성 업데이트로 WebSocket 기본 서버 주소를 외부 설정값으로 주입하여 배포 환경에 맞게 자동 적용되도록 개선.
- **Refactor**
  - 하드코드된 WebSocket 주소를 제거하고 구성 기반으로 전환해 관리성을 향상.
- **Impact**
  - 연결 신뢰성과 환경 간 호환성 향상.
  - 기능 동작과 UI에는 변화 없음.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->