### PR TITLE
:twisted_rightwards_arrows: :: [#258] - 애플리케이션 리스트 조회시 응답되는 정보에 맞는 구조체를 사용하도록 리펙토링

### DIFF
--- a/api/exec/get_application.go
+++ b/api/exec/get_application.go
@@ -2,9 +2,10 @@ package exec
 
 import (
 	"encoding/json"
+	"strings"
+
 	"github.com/dolong2/dcd-cli/api"
 	"github.com/dolong2/dcd-cli/api/exec/response"
-	"strings"
 )
 
 func GetApplications(workspaceId string) (*response.ApplicationListResponse, error) {
@@ -54,7 +55,7 @@ func GetApplicationsByLabels(workspaceId string, labels []string) (*response.App
 	return &applicationListResponse, nil
 }
 
-func GetApplication(workspaceId string, applicationId string) (*response.ApplicationResponse, error) {
+func GetApplication(workspaceId string, applicationId string) (*response.ApplicationDetailResponse, error) {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -67,11 +68,11 @@ func GetApplication(workspaceId string, applicationId string) (*response.Applica
 		return nil, err
 	}
 
-	var applicationResponse response.ApplicationResponse
-	err = json.Unmarshal(result, &applicationResponse)
+	var applicationDetailResponse response.ApplicationDetailResponse
+	err = json.Unmarshal(result, &applicationDetailResponse)
 	if err != nil {
 		return nil, err
 	}
 
-	return &applicationResponse, nil
+	return &applicationDetailResponse, nil
 }

--- a/api/exec/response/application.go
+++ b/api/exec/response/application.go
@@ -4,25 +4,25 @@ type CreateApplicationResponse struct {
 	ApplicationId string `json:"applicationId"`
 }
 
-type ApplicationResponse struct {
-	Id              string            `json:"id"`
-	Name            string            `json:"name"`
-	Description     string            `json:"description"`
-	ApplicationType string            `json:"applicationType"`
-	GithubUrl       string            `json:"githubUrl"`
-	Env             map[string]string `json:"env"`
-	Port            int               `json:"port"`
-	ExternalPort    int               `json:"externalPort"`
-	Version         string            `json:"version"`
-	Status          string            `json:"status"`
-	FailureReason   string            `json:"failureReason"`
-	FailureReasonDetail string        `json:"failureReasonDetail"`
-	InitialScripts  []string          `json:"initialScripts"`
-	Labels          []string          `json:"labels"`
+type ApplicationDetailResponse struct {
+	Id                  string            `json:"id"`
+	Name                string            `json:"name"`
+	Description         string            `json:"description"`
+	ApplicationType     string            `json:"applicationType"`
+	GithubUrl           string            `json:"githubUrl"`
+	Env                 map[string]string `json:"env"`
+	Port                int               `json:"port"`
+	ExternalPort        int               `json:"externalPort"`
+	Version             string            `json:"version"`
+	Status              string            `json:"status"`
+	FailureReason       string            `json:"failureReason"`
+	FailureReasonDetail string            `json:"failureReasonDetail"`
+	InitialScripts      []string          `json:"initialScripts"`
+	Labels              []string          `json:"labels"`
 }
 
 type ApplicationListResponse struct {
-	Applications []ApplicationResponse `json:"list"`
+	Applications []ApplicationDetailResponse `json:"list"`
 }
 
 type applicationSimpleResponse struct {

--- a/api/exec/response/application.go
+++ b/api/exec/response/application.go
@@ -21,8 +21,21 @@ type ApplicationDetailResponse struct {
 	Labels              []string          `json:"labels"`
 }
 
+type ApplicationResponse struct {
+	Id              string    `json:"id"`
+	Name            string    `json:"name"`
+	Description     string    `json:"description"`
+	ApplicationType string    `json:"applicationType"`
+	GithubUrl       string    `json:"githubUrl"`
+	Port            int       `json:"port"`
+	ExternalPort    int       `json:"externalPort"`
+	Version         string    `json:"version"`
+	Status          string    `json:"status"`
+	Labels          []string  `json:"labels"`
+}
+
 type ApplicationListResponse struct {
-	Applications []ApplicationDetailResponse `json:"list"`
+	Applications []ApplicationResponse `json:"list"`
 }
 
 type applicationSimpleResponse struct {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -268,7 +268,7 @@ func printApplication(application response.ApplicationDetailResponse) {
 	table.Render()
 }
 
-func printApplicationList(applicationList []response.ApplicationDetailResponse) {
+func printApplicationList(applicationList []response.ApplicationResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
 	table.SetAlignment(tablewriter.ALIGN_CENTER)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,6 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/dolong2/dcd-cli/api/exec"
 	"github.com/dolong2/dcd-cli/api/exec/response"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
@@ -9,9 +13,6 @@ import (
 	"github.com/dolong2/dcd-cli/cmd/util"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"os"
-	"strconv"
-	"strings"
 )
 
 // getCmd represents the get command
@@ -225,7 +226,7 @@ func init() {
 	getCmd.Flags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n워크스페이스를 가져올때 해당 플래그를 사용하면, 해당 플래그는 무시됩니다.\n리소스 아이디를 사용한다면, 이 플래그는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
 }
 
-func printApplication(application response.ApplicationResponse) {
+func printApplication(application response.ApplicationDetailResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
@@ -267,7 +268,7 @@ func printApplication(application response.ApplicationResponse) {
 	table.Render()
 }
 
-func printApplicationList(applicationList []response.ApplicationResponse) {
+func printApplicationList(applicationList []response.ApplicationDetailResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
 	table.SetAlignment(tablewriter.ALIGN_CENTER)


### PR DESCRIPTION
## 개요
* 애플리케이션 리스트를 조회할때 응답되는 정보만 정의된 구조체를 사용하도록 리펙토링합니다.
## 작업내용
* 기존 `ApplicationResponse` 구조체의 네이밍을 `ApplicationDetailResponse`로 변경
* `ApplicationResponse`는 리스트 정보 조회시 응답되는 정보만 정의
* `printApplication` 함수에서 `ApplicationDetailResponse`를 매개변수로 받도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 응용 프로그램 상세 정보 조회 시 환경 변수, 초기 스크립트, 레이블 및 오류 상세 정보를 포함한 더 포괄적인 메타데이터가 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->