### PR TITLE
:twisted_rightwards_arrows: :: [#264] - 웹소켓 사용 부분에 중복되는 인터럽트 감지 로직 제거

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -66,20 +66,38 @@ var execCmd = &cobra.Command{
 
 			// [2] 메시지 송신 루프 (메인 흐름)
 			go func() {
+				type lineResult struct {
+					line string
+					err  error
+				}
+				lineChan := make(chan lineResult, 1)
+
 				reader := bufio.NewReader(os.Stdin)
+				// stdin 읽기 전용 내부 고루틴: ReadLine이 블로킹되므로 분리
+				go func() {
+					for {
+						line, _, err := reader.ReadLine()
+						select {
+						case lineChan <- lineResult{string(line), err}:
+						case <-ctx.Done():
+							return
+						}
+						if err != nil {
+							return
+						}
+					}
+				}()
+
 				for {
 					select {
 					case <-ctx.Done():
 						return
-					default:
-						input, _, err := reader.ReadLine()
-						if err != nil {
-							errChan <- err
+					case result := <-lineChan:
+						if result.err != nil {
+							errChan <- result.err
 							return
 						}
-
-						err = websocket.SendMessage(conn, string(input))
-						if err != nil {
+						if err := websocket.SendMessage(conn, result.line); err != nil {
 							errChan <- err
 							return
 						}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -2,13 +2,15 @@ package cmd
 
 import (
 	"bufio"
+	"context"
+	"os"
+	"os/signal"
+
 	"github.com/dolong2/dcd-cli/api/exec"
 	cmdError "github.com/dolong2/dcd-cli/cmd/err"
 	"github.com/dolong2/dcd-cli/cmd/util"
 	"github.com/dolong2/dcd-cli/websocket"
 	"github.com/spf13/cobra"
-	"os"
-	"os/signal"
 )
 
 // execCmd represents the exec command
@@ -29,6 +31,9 @@ var execCmd = &cobra.Command{
 		}
 
 		if ws {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			conn, err := websocket.Connect(applicationId)
 			if err != nil {
 				return cmdError.NewCmdError(1, err.Error())
@@ -45,13 +50,17 @@ var execCmd = &cobra.Command{
 			// [1] 메시지 수신을 위한 독립적인 고루틴 실행
 			go func() {
 				for {
-					message, err := websocket.ReadMessage(conn)
-					if err != nil {
-						errChan <- err
+					select {
+					case <-ctx.Done():
 						return
+					default:
+						message, err := websocket.ReadMessage(conn)
+						if err != nil {
+							errChan <- err
+							return
+						}
+						cmd.Print(message)
 					}
-					// 서버가 빈 메시지를 주든 아니든, 오는 대로 바로 출력
-					cmd.Print(message) 
 				}
 			}()
 
@@ -59,16 +68,21 @@ var execCmd = &cobra.Command{
 			go func() {
 				reader := bufio.NewReader(os.Stdin)
 				for {
-					input, _, err := reader.ReadLine()
-					if err != nil {
-						errChan <- err
+					select {
+					case <-ctx.Done():
 						return
-					}
+					default:
+						input, _, err := reader.ReadLine()
+						if err != nil {
+							errChan <- err
+							return
+						}
 
-					err = websocket.SendMessage(conn, string(input))
-					if err != nil {
-						errChan <- err
-						return
+						err = websocket.SendMessage(conn, string(input))
+						if err != nil {
+							errChan <- err
+							return
+						}
 					}
 				}
 			}()

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -76,6 +76,7 @@ var execCmd = &cobra.Command{
 			// [3] 인터럽트 및 에러 대기 제어
 			select {
 			case <-interrupt:
+				cmd.Println()
 				return nil
 			case err := <-errChan:
 				return cmdError.NewCmdError(1, err.Error())

--- a/websocket/websocket_client.go
+++ b/websocket/websocket_client.go
@@ -1,12 +1,9 @@
 package websocket
 
 import (
-	"fmt"
 	"github.com/dolong2/dcd-cli/api/exec"
 	"github.com/gorilla/websocket"
 	"net/http"
-	"os"
-	"os/signal"
 )
 
 var baseUrl string
@@ -34,20 +31,6 @@ func Close(conn *websocket.Conn) error {
 }
 
 func SendMessage(conn *websocket.Conn, message string) error {
-	// 인터럽트 신호를 받기 위한 채널
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-
-	select {
-	case <-interrupt:
-		fmt.Println("인터럽트 신호를 받았습니다.\n커넥션을 종료합니다...")
-		err := conn.Close()
-		if err != nil {
-			return err
-		}
-		return nil
-	default:
-	}
 	return conn.WriteMessage(websocket.TextMessage, []byte(message))
 }
 


### PR DESCRIPTION
## 개요
* 웹소켓 사용 부분에 중복되는 인터럽트 감지 로직을 제거합니다.
## 작업내용
* SendMessage 메서드에 정의된 인터럽트 감지 로직 제거
* 인터럽트 처리후 개행 추가
* 고루틴 제어를 위한 컨텍스트 핸들링 로직 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 웹소켓 송수신 로직의 안정성 개선을 위해 내부 구조를 개선했습니다.
  * 불필요한 의존성을 제거하여 코드를 간소화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dolong2/dcd-cli/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->