### PR TITLE
:twisted_rightwards_arrows: :: [#266] - 웹소켓을 닫을때 Close message를 보내고 닫도록 수정

### DIFF
--- a/websocket/websocket_client.go
+++ b/websocket/websocket_client.go
@@ -1,9 +1,11 @@
 package websocket
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/dolong2/dcd-cli/api/exec"
 	"github.com/gorilla/websocket"
-	"net/http"
 )
 
 var baseUrl string
@@ -27,7 +29,16 @@ func Connect(applicationId string) (*websocket.Conn, error) {
 }
 
 func Close(conn *websocket.Conn) error {
-	return conn.Close()
+	err := conn.SetWriteDeadline(time.Now().Add(time.Second))
+	if err != nil {
+		return err
+	}
+    err = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+    if err != nil {
+        return err
+    }
+    err = conn.Close()
+    return err
 }
 
 func SendMessage(conn *websocket.Conn, message string) error {


### PR DESCRIPTION
## 개요
* 웹소켓을 닫을때 Close message를 보내고 닫도록 수정합니다.
## 작업내용
* `websocket_client`의 Close 메서드에 Close Message 전송 로직 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?