### PR TITLE
:twisted_rightwards_arrows: :: [#272] - 커맨드 계층 리펙토링

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -27,5 +27,4 @@ func init() {
 	rootCmd.AddCommand(applicationCmd)
 
 	applicationCmd.PersistentFlags().StringP("workspace", "w", "", "워크스페이스 아이디")
-	applicationCmd.PersistentFlags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+// context에 값을 담을 때 사용할 전용 커스텀 타입 (충돌 방지)
+type contextKey string
+const applicationId contextKey = "application"
+
+var applicationCmd = &cobra.Command{
+	Use:   "application [applicationId]",
+	Short: "애플리케이션 관련 작업을 식별하기 위한 커맨드",
+	Long:  `애플리케이션에 관련된 작업을 수행하는 커맨드입니다.`,
+	Aliases: []string{"app"},
+	TraverseChildren: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// 공통적으로 args에 있는 applicationId를 컨텍스트로 전달
+		if len(args) > 0 {
+			ctx := context.WithValue(cmd.Context(), applicationId, args[0])
+			cmd.SetContext(ctx)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(applicationCmd)
+
+	applicationCmd.PersistentFlags().StringP("workspace", "w", "", "워크스페이스 아이디")
+	applicationCmd.PersistentFlags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
+}

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -6,12 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// context에 값을 담을 때 사용할 전용 커스텀 타입 (충돌 방지)
-type contextKey string
 const applicationId contextKey = "application"
 
 var applicationCmd = &cobra.Command{
-	Use:   "application [applicationId]",
+	Use:   "application",
 	Short: "애플리케이션 관련 작업을 식별하기 위한 커맨드",
 	Long:  `애플리케이션에 관련된 작업을 수행하는 커맨드입니다.`,
 	Aliases: []string{"app"},

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -25,7 +25,10 @@ var connectCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, "필요한 인자는 2개입니다.\n커맨드 사용법을 확인해주세요.")
 		}
 
-		domainId := args[0]
+		domainId, ok := cmd.Context().Value(domainId).(string)
+		if !ok {
+			return cmdError.NewCmdError(1, "도메인 아이디가 입력되어야합니다.")
+		}
 		applicationId := args[1]
 
 		err = exec.ConnectDomain(workspaceId, domainId, applicationId)
@@ -38,7 +41,7 @@ var connectCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(connectCmd)
+	domainCmd.AddCommand(connectCmd)
 
 	connectCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -44,4 +44,6 @@ var deployCmd = &cobra.Command{
 
 func init() {
 	applicationCmd.AddCommand(deployCmd)
+
+	applicationCmd.PersistentFlags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -45,5 +45,5 @@ var deployCmd = &cobra.Command{
 func init() {
 	applicationCmd.AddCommand(deployCmd)
 
-	applicationCmd.PersistentFlags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
+	deployCmd.PersistentFlags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -30,10 +30,10 @@ var deployCmd = &cobra.Command{
 			return nil
 		}
 
-		if len(args) == 0 {
+		applicationId, ok := cmd.Context().Value(applicationId).(string)
+		if !ok {
 			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
-		applicationId := args[0]
 		err = exec.DeployApplication(workspaceId, applicationId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
@@ -43,8 +43,5 @@ var deployCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(deployCmd)
-
-	deployCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
-	deployCmd.Flags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기 위한 라벨.\n이 플래그를 사용했는데 애플리케이션 아이디를 입력한다면 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
+	applicationCmd.AddCommand(deployCmd)
 }

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -21,13 +21,11 @@ var disconnectCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, err.Error())
 		}
 
-		if len(args) == 0 {
+		domainId, ok := cmd.Context().Value(domainId).(string)
+		if !ok {
 			return cmdError.NewCmdError(1, "도메인 아이디가 입력되어야합니다.")
-		} else if len(args) > 1 {
-			return cmdError.NewCmdError(1, "도메인 아이디만 입력되어야합니다.")
 		}
-
-		domainId := args[0]
+		
 		err = exec.DisconnectDomain(workspaceId, domainId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
@@ -38,7 +36,7 @@ var disconnectCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(disconnectCmd)
+	domainCmd.AddCommand(disconnectCmd)
 
 	disconnectCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
 }

--- a/cmd/domain.go
+++ b/cmd/domain.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+const domainId contextKey = "domain"
+
+var domainCmd = &cobra.Command{
+	Use:   "domain",
+	Short: "도메인 관련 작업을 식별하기 위한 커맨드",
+	Long:  `도메인에 관련된 작업을 수행하는 커맨드입니다.`,
+	Aliases: []string{"dom"},
+	TraverseChildren: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// 공통적으로 args에 있는 domainId를 컨텍스트로 전달
+		if len(args) > 0 {
+			ctx := context.WithValue(cmd.Context(), domainId, args[0])
+			cmd.SetContext(ctx)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(domainCmd)
+
+	domainCmd.PersistentFlags().StringP("workspace", "w", "", "워크스페이스 아이디")
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -20,10 +20,10 @@ var execCmd = &cobra.Command{
 	Long: `이 커맨드는 애플리케이션에 커맨드를 실행할 수 있는 커맨드입니다.
 웹소켓을 통해서 애플리케이션 내부에 접근할 수 있습니다.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
+		applicationId, ok := cmd.Context().Value(applicationId).(string)
+		if !ok {
 			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
-		applicationId := args[0]
 
 		ws, err := cmd.Flags().GetBool("ws")
 		if err != nil {
@@ -139,9 +139,8 @@ var execCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(execCmd)
+	applicationCmd.AddCommand(execCmd)
 
 	execCmd.Flags().StringP("command", "c", "", "애플리케이션에 실행할 명령")
-	execCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
 	execCmd.Flags().Bool("ws", false, "웹소켓 사용 여부")
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -10,7 +10,7 @@ import (
 
 // logsCmd represents the logs command
 var logsCmd = &cobra.Command{
-	Use:   "logs",
+	Use:   "logs <applicationId>",
 	Short: "애플리케이션의 로그를 조회하는 커맨드",
 	Long:  `애플리케이션의 로그를 조회하는 커맨드입니다.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -19,10 +19,10 @@ var logsCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, err.Error())
 		}
 
-		if len(args) == 0 {
+		applicationId, ok := cmd.Context().Value(applicationId).(string)
+		if !ok {
 			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
-		applicationId := args[0]
 		logs, err := exec.GetLog(workspaceId, applicationId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
@@ -36,7 +36,5 @@ var logsCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(logsCmd)
-
-	logsCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
+	applicationCmd.AddCommand(logsCmd)
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -21,9 +21,9 @@ var mountCmd = &cobra.Command{
 		if len(args) != 2 {
 			return cmdError.NewCmdError(1, "볼륨 아이디 혹은 마운트 경로가 입력되지 않았습니다.")
 		}
-		volumeId := args[0]
-		if volumeId == "" {
-			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되지 않았습니다.")
+		volumeId, ok := cmd.Context().Value(volumeId).(string)
+		if !ok {
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 		mountPath := args[1]
 		if mountPath == "" {
@@ -53,9 +53,8 @@ var mountCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(mountCmd)
+	volumeCmd.AddCommand(mountCmd)
 
-	mountCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
 	mountCmd.Flags().StringP("application", "a", "", "볼륨을 마운트할 애플리케이션 아이디")
 	mountCmd.Flags().BoolP("readOnly", "", false, "읽기 전용으로 마운트")
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -23,7 +23,7 @@ var mountCmd = &cobra.Command{
 		}
 		volumeId, ok := cmd.Context().Value(volumeId).(string)
 		if !ok {
-			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
+			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되어야합니다.")
 		}
 		mountPath := args[1]
 		if mountPath == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,9 @@ import (
 	"os"
 )
 
+// context에 값을 담을 때 사용할 전용 커스텀 타입 (충돌 방지)
+type contextKey string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "dcd",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,4 +46,6 @@ var runCmd = &cobra.Command{
 
 func init() {
 	applicationCmd.AddCommand(runCmd)
+
+	runCmd.PersistentFlags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,10 +32,10 @@ var runCmd = &cobra.Command{
 			return nil
 		}
 
-		if len(args) == 0 {
+		applicationId, ok := cmd.Context().Value(applicationId).(string)
+		if !ok {
 			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
-		applicationId := args[0]
 		err = exec.RunApplication(workspaceId, applicationId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
@@ -45,8 +45,5 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(runCmd)
-
-	runCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
-	runCmd.Flags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
+	applicationCmd.AddCommand(runCmd)
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -31,10 +31,10 @@ var stopCmd = &cobra.Command{
 			return nil
 		}
 
-		if len(args) == 0 {
+		applicationId, ok := cmd.Context().Value(applicationId).(string)
+		if !ok {
 			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
-		applicationId := args[0]
 		err = exec.StopApplication(workspaceId, applicationId)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
@@ -44,8 +44,5 @@ var stopCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(stopCmd)
-
-	stopCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
-	stopCmd.Flags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용한다면 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
+	applicationCmd.AddCommand(stopCmd)
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -45,4 +45,6 @@ var stopCmd = &cobra.Command{
 
 func init() {
 	applicationCmd.AddCommand(stopCmd)
+
+	stopCmd.PersistentFlags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기위한 라벨.\n이 플래그를 사용할때 명시한 애플리케이션 아이디는 무시됩니다.\nex). -l test-label-1 -l test-label-2")
 }

--- a/cmd/unmount.go
+++ b/cmd/unmount.go
@@ -19,12 +19,9 @@ var unmountCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, err.Error())
 		}
 
-		if len(args) != 1 {
-			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되지 않았습니다.")
-		}
-		volumeId := args[0]
-		if volumeId == "" {
-			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되지 않았습니다.")
+		volumeId, ok := cmd.Context().Value(volumeId).(string)
+		if !ok {
+			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
 		}
 
 		applicationId, err := cmd.Flags().GetString("application")
@@ -45,7 +42,7 @@ var unmountCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(unmountCmd)
+	volumeCmd.AddCommand(unmountCmd)
 
 	unmountCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
 	unmountCmd.Flags().StringP("application", "a", "", "볼륨을 마운트할 애플리케이션 아이디")

--- a/cmd/unmount.go
+++ b/cmd/unmount.go
@@ -21,7 +21,7 @@ var unmountCmd = &cobra.Command{
 
 		volumeId, ok := cmd.Context().Value(volumeId).(string)
 		if !ok {
-			return cmdError.NewCmdError(1, "애플리케이션 아이디가 입력되어야합니다.")
+			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되어야합니다.")
 		}
 
 		applicationId, err := cmd.Flags().GetString("application")

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -10,8 +10,8 @@ const volumeId contextKey = "volume"
 
 var volumeCmd = &cobra.Command{
 	Use:   "volume",
-	Short: "애플리케이션 관련 작업을 식별하기 위한 커맨드",
-	Long:  `애플리케이션에 관련된 작업을 수행하는 커맨드입니다.`,
+	Short: "볼륨 관련 작업을 식별하기 위한 커맨드",
+	Long:  `볼륨에 관련된 작업을 수행하는 커맨드입니다.`,
 	Aliases: []string{"vol"},
 	TraverseChildren: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+const volumeId contextKey = "volume"
+
+var volumeCmd = &cobra.Command{
+	Use:   "volume",
+	Short: "애플리케이션 관련 작업을 식별하기 위한 커맨드",
+	Long:  `애플리케이션에 관련된 작업을 수행하는 커맨드입니다.`,
+	Aliases: []string{"vol"},
+	TraverseChildren: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// 공통적으로 args에 있는 applicationId를 컨텍스트로 전달
+		if len(args) > 0 {
+			ctx := context.WithValue(cmd.Context(), volumeId, args[0])
+			cmd.SetContext(ctx)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(volumeCmd)
+
+	volumeCmd.PersistentFlags().StringP("workspace", "w", "", "워크스페이스 아이디")
+}


### PR DESCRIPTION
## 개요
* 커맨드 계층 구조를 수정합니다..
## 작업내용
* 애플리케이션 부모 커맨드 추가
  * 실행, 정지, 배포, 로그, 명령 실행 등을 자식 커맨드로 수정
* 볼륨 부모 커맨드 추가
  * 마운트, 언마운트 커맨드를 자식 커맨드로 수정
* 도메인 부모 커맨드 추가
  * 연결, 연결해제 커맨드를 자식 커맨드로 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI 명령어를 계층화: domain, application, volume 하위에 관련 명령어들을 재배치했습니다.
* **Bug Fixes / Behavior**
  * 명령어들이 위치 인자 대신 내부 컨텍스트에서 대상 ID를 일관되게 취득하도록 수정되어 입력 검증과 오류 메시지가 명확해졌습니다.
* **New Features**
  * 일부 플래그가 상위 명령어의 persistent 플래그로 이동되어 하위 명령에서 자동 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->