### PR TITLE
:twisted_rightwards_arrows: :: [#274] - 리소스 매핑 로직 수정

### DIFF
--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -17,7 +17,7 @@ func CreateByPath(fileDirectory string) error {
 		return err
 	}
 
-	unmarshal, err := resolveFileExtension(fileDirectory)
+	unmarshal, err := util.ResolveFileExtension(fileDirectory)
 	if err != nil {
 		return err
 	}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -106,7 +106,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		workspaceId, err := getWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			return "", err
 		}
@@ -141,7 +141,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		workspaceId, err := getWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			return "", err
 		}
@@ -178,7 +178,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		workspaceId, err := getWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			return "", err
 		}
@@ -211,7 +211,7 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		workspaceId, err := getWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			return "", err
 		}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -3,10 +3,12 @@ package exec
 import (
 	"encoding/json"
 	"errors"
+	"os"
+
 	"github.com/dolong2/dcd-cli/api"
 	"github.com/dolong2/dcd-cli/api/exec/response"
 	"github.com/dolong2/dcd-cli/api/exec/template"
-	"os"
+	"github.com/dolong2/dcd-cli/api/exec/util"
 )
 
 func CreateByPath(fileDirectory string) error {
@@ -25,7 +27,7 @@ func CreateByPath(fileDirectory string) error {
 	}
 
 	if resourceId != "" {
-		err := MapFileToResourceId(fileDirectory, resourceId)
+		err := util.MapFileToResourceId(fileDirectory, resourceId)
 		if err != nil {
 			return err
 		}

--- a/api/exec/create.go
+++ b/api/exec/create.go
@@ -146,14 +146,20 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 
 		if envTemplate.Spec.ApplicationLabelList == nil && envTemplate.Spec.ApplicationIdList == nil {
 			return "", errors.New("애플리케이션 아이디 혹은 라벨이 입력되어야함")
-		} else {
-			_, err := api.SendPost("/"+workspaceId+"/env", header, map[string]string{}, request)
-			if err != nil {
-				return "", err
-			}
 		}
 
-		return "", nil
+		result, err := api.SendPost("/"+workspaceId+"/env", header, map[string]string{}, request)
+		if err != nil {
+			return "", err
+		}
+
+		putEnvResponse := response.PutEnvResponse{}
+		err = json.Unmarshal(result, &putEnvResponse)
+		if err != nil {
+			return "", err
+		}
+
+		return putEnvResponse.EnvId, nil
 	case "DOMAIN":
 		var domainTemplate template.DomainTemplate
 		err := unmarshal(content, &domainTemplate)
@@ -208,11 +214,18 @@ func create(content []byte, unmarshal func([]byte, interface{}) (err error)) (st
 			return "", err
 		}
 
-		_, err = api.SendPost("/"+workspaceId+"/volume", header, map[string]string{}, request)
+		result, err := api.SendPost("/"+workspaceId+"/volume", header, map[string]string{}, request)
 		if err != nil {
 			return "", err
 		}
-		return "", nil
+
+		createVolumeResponse := response.CreateVolumeResponse{}
+		err = json.Unmarshal(result, &createVolumeResponse)
+		if err != nil {
+			return "", err
+		}
+
+		return createVolumeResponse.VolumeId, nil
 	default:
 		return "", errors.New("지원되지 않는 리소스 타입입니다")
 	}

--- a/api/exec/response/env.go
+++ b/api/exec/response/env.go
@@ -1,5 +1,9 @@
 package response
 
+type PutEnvResponse struct {
+	EnvId string `json:"envId"`
+}
+
 type EnvListResponse struct {
 	List []envSimpleResponse `json:"list"`
 }

--- a/api/exec/response/volume.go
+++ b/api/exec/response/volume.go
@@ -1,5 +1,9 @@
 package response
 
+type CreateVolumeResponse struct {
+	VolumeId string `json:"volumeId"`
+}
+
 type VolumeListResponse struct {
 	List []volumeSimpleResponse `json:"list"`
 }

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -3,11 +3,13 @@ package exec
 import (
 	"encoding/json"
 	"errors"
-	"github.com/dolong2/dcd-cli/api"
-	"github.com/dolong2/dcd-cli/api/exec/template"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
+
+	"github.com/dolong2/dcd-cli/api"
+	"github.com/dolong2/dcd-cli/api/exec/template"
+	"github.com/dolong2/dcd-cli/api/exec/util"
+	"gopkg.in/yaml.v3"
 )
 
 func UpdateByTemplate(resourceId string, rawTemplate string) error {
@@ -35,7 +37,7 @@ func UpdateByPath(resourceId string, fileDirectory string) error {
 }
 
 func UpdateByOnlyPath(fileDirectory string) error {
-	resourceId, err := GetResourceIdByFilePath(fileDirectory)
+	resourceId, err := util.GetResourceIdByFilePath(fileDirectory)
 
 	if err != nil {
 		return errors.New("파일이랑 매핑되는 리소스 아이디가 존재하지 않습니다.")

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -27,7 +27,7 @@ func UpdateByPath(resourceId string, fileDirectory string) error {
 		return err
 	}
 
-	unmarshal, err := resolveFileExtension(fileDirectory)
+	unmarshal, err := util.ResolveFileExtension(fileDirectory)
 	if err != nil {
 		return err
 	}

--- a/api/exec/update.go
+++ b/api/exec/update.go
@@ -105,7 +105,7 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 			return err
 		}
 	case "APPLICATION":
-		workspaceId, err := getWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func update(resourceId string, content []byte, unmarshal func([]byte, interface{
 			return err
 		}
 	case "ENV":
-		workspaceId, err := getWorkspaceId()
+		workspaceId, err := util.GetWorkspaceId()
 		if err != nil {
 			return err
 		}

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -64,24 +64,6 @@ getTokenInfo:
 	return tokenInfo.AccessToken, nil
 }
 
-func getWorkspaceId() (string, error) {
-	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
-	if err != nil {
-		return "", errors.New("워크스페이스 정보를 찾을수없습니다.")
-	}
-
-	var workspaceInfo map[string]interface{}
-
-	err = json.Unmarshal(rawWorkspaceInfo, &workspaceInfo)
-	if err != nil {
-		return "", errors.New("워크스페이스 정보가 올바르지 않습니다.")
-	}
-
-	workspaceId := workspaceInfo["workspaceId"].(string)
-
-	return workspaceId, nil
-}
-
 func resolveFileExtension(fileDirectory string) (func([]byte, interface{}) (err error), error) {
 	ext := filepath.Ext(fileDirectory)
 

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/dolong2/dcd-cli/api/exec/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -81,86 +80,6 @@ func getWorkspaceId() (string, error) {
 	workspaceId := workspaceInfo["workspaceId"].(string)
 
 	return workspaceId, nil
-}
-
-func MapFileToResourceId(fileDirectory string, resourceId string) error {
-	if resourceId == "" || fileDirectory == "" {
-		return errors.New("리소스 아이디와 파일경로는 필수적으로 입력되어야합니다.")
-	}
-
-	resourceMappingInfoPath := "./dcd-info/resource-mapping-info.json"
-
-	// 디렉토리가 없으면 생성
-	resourceMappingDir := filepath.Dir(resourceMappingInfoPath)
-	if err := os.MkdirAll(resourceMappingDir, 0755); err != nil {
-		return errors.New("dcd-info 정보 디렉토리를 생성하는데 실패했습니다.")
-	}
-
-	fileKey, err := util.GetFileKey(fileDirectory)
-	if err != nil {
-		return err
-	}
-
-	// JSON 파일 읽기 또는 파일이 없을 경우 새로 생성
-	file, err := os.ReadFile(resourceMappingInfoPath)
-	var data map[string]string
-
-	if os.IsNotExist(err) {
-		// 파일이 없을 경우 초기 맵을 생성
-		data = make(map[string]string)
-	} else if err != nil {
-		return err
-	} else {
-		// 파일이 존재하는 경우 JSON 데이터를 언마셜링
-		if err := json.Unmarshal(file, &data); err != nil {
-			return err
-		}
-	}
-
-	// 새로운 key:value 쌍 추가
-	data[fileKey] = resourceId
-
-	// 수정된 맵을 JSON으로 마셜링
-	updatedJSON, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	// JSON 파일에 저장
-	if err := os.WriteFile(resourceMappingInfoPath, updatedJSON, 0644); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func GetResourceIdByFilePath(fileDirectory string) (string, error) {
-	// JSON 파일 경로
-	filePath := "./dcd-info/resource-mapping-info.json"
-
-	// JSON 파일 읽기
-	resourceMappingInfo, err := os.ReadFile(filePath)
-	if err != nil {
-		return "", err
-	}
-
-	// JSON 데이터 언마샬링
-	var data map[string]string
-	if err := json.Unmarshal(resourceMappingInfo, &data); err != nil {
-		return "", err
-	}
-
-	fileKey, err := util.GetFileKey(fileDirectory)
-	if err != nil {
-		return "", err
-	}
-	resourceId := data[fileKey]
-
-	if resourceId == "" {
-		return "", errors.New("해당 템플릿에 매핑된 리소스 아이디를 찾을 수 없음")
-	}
-
-	return resourceId, nil
 }
 
 func resolveFileExtension(fileDirectory string) (func([]byte, interface{}) (err error), error) {

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -3,10 +3,12 @@ package exec
 import (
 	"encoding/json"
 	"errors"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/dolong2/dcd-cli/api/exec/util"
+	"gopkg.in/yaml.v3"
 )
 
 func GetAccessToken() (string, error) {
@@ -94,7 +96,11 @@ func MapFileToResourceId(fileDirectory string, resourceId string) error {
 		return errors.New("dcd-info 정보 디렉토리를 생성하는데 실패했습니다.")
 	}
 
-	fileName := filepath.Base(fileDirectory)
+	fileKey, err := util.GetFileKey(fileDirectory)
+	if err != nil {
+		return err
+	}
+
 	// JSON 파일 읽기 또는 파일이 없을 경우 새로 생성
 	file, err := os.ReadFile(resourceMappingInfoPath)
 	var data map[string]string
@@ -112,7 +118,7 @@ func MapFileToResourceId(fileDirectory string, resourceId string) error {
 	}
 
 	// 새로운 key:value 쌍 추가
-	data[fileName] = resourceId
+	data[fileKey] = resourceId
 
 	// 수정된 맵을 JSON으로 마셜링
 	updatedJSON, err := json.MarshalIndent(data, "", "  ")
@@ -144,8 +150,11 @@ func GetResourceIdByFilePath(fileDirectory string) (string, error) {
 		return "", err
 	}
 
-	templateName := filepath.Base(fileDirectory)
-	resourceId := data[templateName]
+	fileKey, err := util.GetFileKey(fileDirectory)
+	if err != nil {
+		return "", err
+	}
+	resourceId := data[fileKey]
 
 	if resourceId == "" {
 		return "", errors.New("해당 템플릿에 매핑된 리소스 아이디를 찾을 수 없음")

--- a/api/exec/util.go
+++ b/api/exec/util.go
@@ -4,10 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"path/filepath"
 	"time"
-
-	"gopkg.in/yaml.v3"
 )
 
 func GetAccessToken() (string, error) {
@@ -62,17 +59,4 @@ getTokenInfo:
 		RefreshTokenExp: refreshTokenExp,
 	}
 	return tokenInfo.AccessToken, nil
-}
-
-func resolveFileExtension(fileDirectory string) (func([]byte, interface{}) (err error), error) {
-	ext := filepath.Ext(fileDirectory)
-
-	switch ext {
-	case ".json":
-		return json.Unmarshal, nil
-	case ".yml", ".yaml":
-		return yaml.Unmarshal, nil
-	default:
-		return nil, errors.New("지원되지 않는 파일 확장자입니다.")
-	}
 }

--- a/api/exec/util/filekey_linux.go
+++ b/api/exec/util/filekey_linux.go
@@ -1,0 +1,23 @@
+//go:build linux || darwin
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func GetFileKey(path string) (string, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("failed to get raw syscall.Stat_t")
+	}
+
+	return fmt.Sprintf("unix-%d-%d", stat.Dev, stat.Ino), nil
+}

--- a/api/exec/util/filekey_linux.go
+++ b/api/exec/util/filekey_linux.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 )
 
-func GetFileKey(path string) (string, error) {
+func getFileKey(path string) (string, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return "", err

--- a/api/exec/util/filekey_window.go
+++ b/api/exec/util/filekey_window.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 )
 
-func GetFileKey(path string) (string, error) {
+func getFileKey(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err

--- a/api/exec/util/filekey_window.go
+++ b/api/exec/util/filekey_window.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func GetFileKey(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var d syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(syscall.Handle(f.Fd()), &d); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("win-%d-%d-%d", d.VolumeSerialNumber, d.FileIndexHigh, d.FileIndexLow), nil
+}

--- a/api/exec/util/get_workspace_info.go
+++ b/api/exec/util/get_workspace_info.go
@@ -19,7 +19,15 @@ func GetWorkspaceId() (string, error) {
 		return "", errors.New("워크스페이스 정보가 올바르지 않습니다.")
 	}
 
-	workspaceId := workspaceInfo["workspaceId"].(string)
+	val, ok := workspaceInfo["workspaceId"]
+    if !ok {
+        return "", errors.New("워크스페이스 ID(workspaceId) 키가 존재하지 않습니다.")
+    }
+
+    workspaceId, ok := val.(string)
+    if !ok {
+        return "", errors.New("워크스페이스 ID가 올바른 문자열 형식이 아닙니다.")
+    }
 
 	return workspaceId, nil
 }

--- a/api/exec/util/get_workspace_info.go
+++ b/api/exec/util/get_workspace_info.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+func GetWorkspaceId() (string, error) {
+	rawWorkspaceInfo, err := os.ReadFile("./dcd-info/workspace-info.json")
+	if err != nil {
+		return "", errors.New("워크스페이스 정보를 찾을수없습니다.")
+	}
+
+	var workspaceInfo map[string]interface{}
+
+	err = json.Unmarshal(rawWorkspaceInfo, &workspaceInfo)
+	if err != nil {
+		return "", errors.New("워크스페이스 정보가 올바르지 않습니다.")
+	}
+
+	workspaceId := workspaceInfo["workspaceId"].(string)
+
+	return workspaceId, nil
+}

--- a/api/exec/util/resolve_file_ext.go
+++ b/api/exec/util/resolve_file_ext.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+func ResolveFileExtension(fileDirectory string) (func([]byte, interface{}) (err error), error) {
+	ext := filepath.Ext(fileDirectory)
+
+	switch ext {
+	case ".json":
+		return json.Unmarshal, nil
+	case ".yml", ".yaml":
+		return yaml.Unmarshal, nil
+	default:
+		return nil, errors.New("지원되지 않는 파일 확장자입니다.")
+	}
+}

--- a/api/exec/util/resource_mapper.go
+++ b/api/exec/util/resource_mapper.go
@@ -1,0 +1,88 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func MapFileToResourceId(fileDirectory string, resourceId string) error {
+	if resourceId == "" || fileDirectory == "" {
+		return errors.New("리소스 아이디와 파일경로는 필수적으로 입력되어야합니다.")
+	}
+
+	resourceMappingInfoPath := "./dcd-info/resource-mapping-info.json"
+
+	// 디렉토리가 없으면 생성
+	resourceMappingDir := filepath.Dir(resourceMappingInfoPath)
+	if err := os.MkdirAll(resourceMappingDir, 0755); err != nil {
+		return errors.New("dcd-info 정보 디렉토리를 생성하는데 실패했습니다.")
+	}
+
+	fileKey, err := getFileKey(fileDirectory)
+	if err != nil {
+		return err
+	}
+
+	// JSON 파일 읽기 또는 파일이 없을 경우 새로 생성
+	file, err := os.ReadFile(resourceMappingInfoPath)
+	var data map[string]string
+
+	if os.IsNotExist(err) {
+		// 파일이 없을 경우 초기 맵을 생성
+		data = make(map[string]string)
+	} else if err != nil {
+		return err
+	} else {
+		// 파일이 존재하는 경우 JSON 데이터를 언마셜링
+		if err := json.Unmarshal(file, &data); err != nil {
+			return err
+		}
+	}
+
+	// 새로운 key:value 쌍 추가
+	data[fileKey] = resourceId
+
+	// 수정된 맵을 JSON으로 마셜링
+	updatedJSON, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// JSON 파일에 저장
+	if err := os.WriteFile(resourceMappingInfoPath, updatedJSON, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetResourceIdByFilePath(fileDirectory string) (string, error) {
+	// JSON 파일 경로
+	filePath := "./dcd-info/resource-mapping-info.json"
+
+	// JSON 파일 읽기
+	resourceMappingInfo, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	// JSON 데이터 언마샬링
+	var data map[string]string
+	if err := json.Unmarshal(resourceMappingInfo, &data); err != nil {
+		return "", err
+	}
+
+	fileKey, err := getFileKey(fileDirectory)
+	if err != nil {
+		return "", err
+	}
+	resourceId := data[fileKey]
+
+	if resourceId == "" {
+		return "", errors.New("해당 템플릿에 매핑된 리소스 아이디를 찾을 수 없음")
+	}
+
+	return resourceId, nil
+}

--- a/api/exec/util/resource_mapper.go
+++ b/api/exec/util/resource_mapper.go
@@ -51,7 +51,11 @@ func MapFileToResourceId(fileDirectory string, resourceId string) error {
 	}
 
 	// JSON 파일에 저장
-	if err := os.WriteFile(resourceMappingInfoPath, updatedJSON, 0644); err != nil {
+	tmpPath := resourceMappingInfoPath + ".tmp"
+	if err := os.WriteFile(tmpPath, updatedJSON, 0644); err != nil {
+	   return err
+	}
+	if err := os.Rename(tmpPath, resourceMappingInfoPath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## 개요
* 리소스 매니페스트랑 아이디를 매핑하는 로직이 모든 리소스에 적용되도록 리펙토링합니다.
## 작업내용
* 환경변수, 볼륨 생성후 리소스 아이디와 매핑할 구조체 추가
* 각 리소스 생성후 리소스 아이디를 통해 매핑하도록 수정
* 파일 매핑시 파일의 고유값을 통해 매핑의 key로 사용하도록 수정
* 여러 유틸 함수를 api/exec/util 패키지로 이동   
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 환경 변수 및 볼륨 생성 시 서버 응답을 올바르게 처리하여 생성된 리소스 ID를 반환하도록 개선

* **New Features**
  * 파일 확장자에 따라 JSON/YAML 파싱을 자동 선택하는 처리 추가
  * 파일 경로와 리소스 ID를 로컬에 저장·조회하는 매핑 기능 추가

* **Refactor**
  * 파일 처리·리소스 매핑·워크스페이스 ID 조회 로직을 별도 유틸리티로 분리
  * 플랫폼별(리눅스/다윈, 윈도우) 안정적인 파일 키 생성 지원 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->