### PR TITLE
:twisted_rightwards_arrows: :: [#276] - 이메일 코드 검증시 용도를 보내도록 수정

### DIFF
--- a/api/exec/certificate_auth_code.go
+++ b/api/exec/certificate_auth_code.go
@@ -6,8 +6,8 @@ import (
 	"github.com/dolong2/dcd-cli/api/exec/request"
 )
 
-func CertificateAuthCode(email string, code string) error {
-	certificateAuthCodeRequest, err := json.Marshal(request.CertificateAuthCodeRequest{Email: email, Code: code})
+func CertificateAuthCode(email string, code string, usage string) error {
+	certificateAuthCodeRequest, err := json.Marshal(request.CertificateAuthCodeRequest{Email: email, Code: code, Usage: usage})
 	if err != nil {
 		return err
 	}

--- a/api/exec/request/auth.go
+++ b/api/exec/request/auth.go
@@ -8,6 +8,7 @@ type SendAuthCodeRequest struct {
 type CertificateAuthCodeRequest struct {
 	Email string `json:"email"`
 	Code  string `json:"code"`
+	Usage string `json:"usage"`
 }
 
 type SignUpRequest struct {

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -34,7 +34,7 @@ var registerCmd = &cobra.Command{
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
-		err = exec.CertificateAuthCode(email, authCode)
+		err = exec.CertificateAuthCode(email, authCode, "SIGNUP")
 		if err != nil {
 			cmd.Println(err.Error())
 			goto enterCode


### PR DESCRIPTION
## 개요
* 이메일 코드 검증시 용도를 보내도록 변경합니다.
## 작업내용
* 이메일 인증 코드 검증 구조체에 usage 필드 추가
* 이메일 인증 메서드에 usage 매개변수 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 회원가입 시 인증 코드 검증 요청에 사용 목적 정보가 함께 전달됩니다.
  * 인증 코드 요청에 용도별 컨텍스트를 포함할 수 있어 검증 처리가 더욱 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->