### PR TITLE
:twisted_rightwards_arrows: :: [#278] - delete 커맨드에서 라벨 사용시 리소스 아이디가 있어야함

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -87,6 +87,5 @@ func init() {
 	rootCmd.AddCommand(deleteCmd)
 
 	deleteCmd.Flags().StringP("workspace", "w", "", "워크스페이스 아이디")
-	deleteCmd.Flags().StringArrayP("label", "l", []string{}, "애플리케이션을 식별하기 위한 라벨.\nex). -l test-label-1 -l test-label-2")
 	deleteCmd.Flags().StringP("application", "a", "", "애플리케이션 아이디")
 }


### PR DESCRIPTION
## 개요
* delete 커맨드에서 라벨 사용시 리소스 아이디가 있어야함
  * 리소스의 삭제는 단건만 진행가능하도록 했던 의도대로 라벨 플래그를 삭제하는 방향으로 수정
## 작업내용
* delete 커맨드에서 label 플래그 제거
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * `delete` 명령에서 애플리케이션 식별에 사용하던 `--label` 및 `-l` 옵션을 제거했습니다.
  * 기존 워크스페이스 및 애플리케이션 관련 옵션은 계속 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->