### PR TITLE
🔀 :: [#281] - 볼륨 리소스에 파일을 삽입하는 커맨드 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`dcd` is a Cobra-based Go CLI for managing resources (workspace, application, domain, env, volume) on the DCD platform, talking to a REST API and, for interactive `exec`, a websocket endpoint.
+
+## Commands
+
+```bash
+# Build the binary (module path: github.com/dolong2/dcd-cli)
+go build -o dcd .
+
+# Run without building
+go run . <subcommand>
+
+# Vet
+go vet ./...
+```
+
+There are no `_test.go` files in the repo currently, so there is no test command to run.
+
+### baseUrl is injected at build time, not hardcoded
+
+`api.baseUrl` (in `api/api_client.go`) and `websocket.baseUrl` (in `websocket/websocket_client.go`) are unexported package-level vars that default to `""`. They are only ever set via `-ldflags -X`, as done in `install.sh`:
+
+```bash
+go build -ldflags="-X github.com/dolong2/dcd-cli/api.baseUrl=https://dcd-api.dolong2.co.kr -X github.com/dolong2/dcd-cli/websocket.baseUrl=wss://dcd-api.dolong2.co.kr" -o dcd
+```
+
+A plain `go build` produces a binary that cannot reach any backend — all HTTP/websocket calls will hit a relative/empty host. When testing against a real or local backend, pass matching `-X` flags for both vars.
+
+### Cross-platform build gotcha (`api/exec/util/filekey_*.go`)
+
+`getFileKey` has per-OS implementations selected by build tag. Go's implicit filename-based build constraint (`_linux`, `_darwin`, `_windows` suffixes) is ANDed with any explicit `//go:build` line in the same file — a file named `foo_linux.go` is restricted to `linux` even if its `//go:build` comment says `linux || darwin`. This is why the Unix implementation lives in `filekey_unix.go` (not `filekey_linux.go`) with `//go:build linux || darwin`; renaming it back to a `_linux.go`/`_darwin.go`-suffixed name will silently break the other OS.
+
+## Architecture
+
+**`cmd/`** — Cobra command definitions. Handlers are thin: parse flags/args, call into `api/exec`, and wrap errors as `cmdError.NewCmdError(code, msg)` (`cmd/err`). `root.go`'s `Execute()` unwraps a returned `*cmdError.CmdError` and calls `os.Exit(cmdErr.Code)`, or exits 1 for any other error. Resource-scoped subcommands (e.g. `application`) use `PersistentPreRun` to stash a positional arg (e.g. `applicationId`) into `cmd.Context()` via a private `contextKey`, which child commands (e.g. `exec.go`) read back out.
+
+**`api/`** — `api_client.go` is a minimal generic HTTP client (`SendGet/Post/Patch/Put/Delete`) that prefixes `targetUrl` with the ldflags-injected `baseUrl`, sets `Authorization`/other headers, and turns non-2xx responses into `httpErr` (`api/err`).
+
+**`api/exec/`** — one file per API operation (`create.go`, `deploy.go`, `get_application.go`, ...), all in `package exec`. Each builds a request, calls `api.Send*`, and unmarshals into a typed response. Sub-packages:
+- `request/`, `response/` — wire DTOs per resource.
+- `template/` — structs (`WorkspaceTemplate`, `ApplicationTemplate`, ...) that parse user-authored YAML/JSON resource definitions (see `example/`). Each has `validateMetadata()` and `ToRequest()` to convert into an `api/exec/request` DTO. `create.go`'s `create()` dispatches on `metadata.resourceType` (`WORKSPACE`/`APPLICATION`/`ENV`/`DOMAIN`/`VOLUME`) read via the shared `ParsingMetaData` struct, parsed once to sniff the type before parsing again into the concrete template.
+- `util/` — `resource_mapper.go` maps a local template file path to its created `resourceId` in `dcd-info/resource-mapping-info.json`, keyed by an OS-level file identity (`getFileKey`, see the build-tag gotcha above), not the path string, so renamed/moved files still resolve. `get_workspace_info.go` and `resolve_file_ext.go` are similar local-state/format helpers.
+
+**`cmd/util/`** — CLI-side helpers distinct from `api/exec/util`: `get_workspace_info.go` resolves the active workspace id (from `--workspace` flag or the saved `dcd-info/workspace-info.json`), `save_workspace_info.go` persists it (written by `cmd/use.go`), `get_resource_type.go`/`print_resource.go` back the generic `get` command.
+
+**`cmd/resource/resource_type.go`** — central registry of resource type names/aliases (e.g. `workspace`/`workspaces`/`ws`) used by `dcd get <type>` to validate and normalize the CLI arg.
+
+**`dcd-info/`** — gitignored local state directory created next to wherever `dcd` is run:
+- `token-info.json` — access/refresh tokens; `api/exec/util.go`'s `GetAccessToken()` reads it, and auto-calls `ReissueToken` + retries (via `goto`) if the access token is expired, erroring out only if the refresh token has also expired.
+- `workspace-info.json` — the workspace set by `dcd use <workspaceId>`.
+- `resource-mapping-info.json` — file-path → resourceId map (see `resource_mapper.go` above).
+
+**`websocket/`** — used only by `dcd application exec --ws`, for an interactive shell into a running application (`/application/exec?applicationId=...`). Has its own independently-injected `baseUrl` (see build note above). `cmd/exec.go` runs separate goroutines for the read loop, the stdin read (nested one level deeper since `bufio.Reader.ReadLine` blocks), and the send loop, coordinated over channels with an `interrupt`/`errChan` select to shut down cleanly on Ctrl-C or a connection error.
+
+**`example/`** — sample `json`/`yml` resource definitions for every resource type, useful as reference for the `template/` structs' expected shape and for manual testing of `dcd create -f <path>`.

--- a/api/api_client.go
+++ b/api/api_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	httpErr "github.com/dolong2/dcd-cli/api/err"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 )
@@ -62,18 +63,37 @@ func SendPut(targetUrl string, header map[string]string, param map[string]string
 	return result, nil
 }
 
-func sendHttpReq(method string, targetUrl string, header map[string]string, param map[string]string, body []byte) ([]byte, error) {
-	if len(param) != 0 {
-		query := url.Values{}
-		for key, value := range param {
-			query.Add(key, value)
-		}
+// SendPostMultipart 파일 업로드와 같이 multipart/form-data로 파일을 전송해야 하는 요청에 사용
+func SendPostMultipart(targetUrl string, header map[string]string, param map[string]string, fileFieldName string, fileName string, fileContent io.Reader) ([]byte, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
 
-		targetUrl = fmt.Sprintf("%s?%s", targetUrl, query.Encode())
+	part, err := writer.CreateFormFile(fileFieldName, fileName)
+	if err != nil {
+		return []byte(""), err
+	}
+	if _, err := io.Copy(part, fileContent); err != nil {
+		return []byte(""), err
+	}
+	if err := writer.Close(); err != nil {
+		return []byte(""), err
 	}
 
-	httpClient := &http.Client{}
-	request, err := http.NewRequest(method, baseUrl+targetUrl, bytes.NewBuffer(body))
+	request, err := http.NewRequest("POST", baseUrl+withQuery(targetUrl, param), body)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	for key, value := range header {
+		request.Header.Set(key, value)
+	}
+
+	return doRequest(request)
+}
+
+func sendHttpReq(method string, targetUrl string, header map[string]string, param map[string]string, body []byte) ([]byte, error) {
+	request, err := http.NewRequest(method, baseUrl+withQuery(targetUrl, param), bytes.NewBuffer(body))
 	if err != nil {
 		return []byte(""), err
 	}
@@ -83,6 +103,24 @@ func sendHttpReq(method string, targetUrl string, header map[string]string, para
 		request.Header.Set(key, value)
 	}
 
+	return doRequest(request)
+}
+
+func withQuery(targetUrl string, param map[string]string) string {
+	if len(param) == 0 {
+		return targetUrl
+	}
+
+	query := url.Values{}
+	for key, value := range param {
+		query.Add(key, value)
+	}
+
+	return fmt.Sprintf("%s?%s", targetUrl, query.Encode())
+}
+
+func doRequest(request *http.Request) ([]byte, error) {
+	httpClient := &http.Client{}
 	httpResponse, err := httpClient.Do(request)
 	if err != nil {
 		return []byte(""), err

--- a/api/api_client.go
+++ b/api/api_client.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	httpErr "github.com/dolong2/dcd-cli/api/err"
@@ -63,23 +64,28 @@ func SendPut(targetUrl string, header map[string]string, param map[string]string
 	return result, nil
 }
 
-// SendPostMultipart 파일 업로드와 같이 multipart/form-data로 파일을 전송해야 하는 요청에 사용
-func SendPostMultipart(targetUrl string, header map[string]string, param map[string]string, fileFieldName string, fileName string, fileContent io.Reader) ([]byte, error) {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
+func SendPostMultipart(ctx context.Context, targetUrl string, header map[string]string, param map[string]string, fileFieldName string, fileName string, fileContent io.Reader) ([]byte, error) {
+	pipeReader, pipeWriter := io.Pipe()
+	writer := multipart.NewWriter(pipeWriter)
 
-	part, err := writer.CreateFormFile(fileFieldName, fileName)
-	if err != nil {
-		return []byte(""), err
-	}
-	if _, err := io.Copy(part, fileContent); err != nil {
-		return []byte(""), err
-	}
-	if err := writer.Close(); err != nil {
-		return []byte(""), err
-	}
+	go func() {
+		part, err := writer.CreateFormFile(fileFieldName, fileName)
+		if err != nil {
+			pipeWriter.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(part, fileContent); err != nil {
+			pipeWriter.CloseWithError(err)
+			return
+		}
+		if err := writer.Close(); err != nil {
+			pipeWriter.CloseWithError(err)
+			return
+		}
+		pipeWriter.Close()
+	}()
 
-	request, err := http.NewRequest("POST", baseUrl+withQuery(targetUrl, param), body)
+	request, err := http.NewRequestWithContext(ctx, "POST", baseUrl+withQuery(targetUrl, param), pipeReader)
 	if err != nil {
 		return []byte(""), err
 	}

--- a/api/exec/upload_volume_file.go
+++ b/api/exec/upload_volume_file.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -8,7 +9,7 @@ import (
 	"github.com/dolong2/dcd-cli/api"
 )
 
-func UploadVolumeFile(workspaceId string, volumeId string, localFilePath string, targetPath string, createDirectory bool) error {
+func UploadVolumeFile(ctx context.Context, workspaceId string, volumeId string, localFilePath string, targetPath string, createDirectory bool) error {
 	header := make(map[string]string)
 	accessToken, err := GetAccessToken()
 	if err != nil {
@@ -20,12 +21,15 @@ func UploadVolumeFile(workspaceId string, volumeId string, localFilePath string,
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
 	param := make(map[string]string)
 	param["path"] = targetPath
 	param["createDirectory"] = strconv.FormatBool(createDirectory)
 
-	_, err = api.SendPostMultipart("/"+workspaceId+"/volume/"+volumeId+"/files", header, param, "file", filepath.Base(localFilePath), file)
-	return err
+	_, uploadErr := api.SendPostMultipart(ctx, "/"+workspaceId+"/volume/"+volumeId+"/files", header, param, "file", filepath.Base(localFilePath), file)
+	closeErr := file.Close()
+	if uploadErr != nil {
+		return uploadErr
+	}
+	return closeErr
 }

--- a/api/exec/upload_volume_file.go
+++ b/api/exec/upload_volume_file.go
@@ -1,0 +1,31 @@
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/dolong2/dcd-cli/api"
+)
+
+func UploadVolumeFile(workspaceId string, volumeId string, localFilePath string, targetPath string, createDirectory bool) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	file, err := os.Open(localFilePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	param := make(map[string]string)
+	param["path"] = targetPath
+	param["createDirectory"] = strconv.FormatBool(createDirectory)
+
+	_, err = api.SendPostMultipart("/"+workspaceId+"/volume/"+volumeId+"/files", header, param, "file", filepath.Base(localFilePath), file)
+	return err
+}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// fileCmd represents the file command
+var fileCmd = &cobra.Command{
+	Use:              "file",
+	Short:            "볼륨 내 파일 관련 작업을 식별하기 위한 커맨드",
+	Long:             `볼륨 내부의 파일을 관리하는 커맨드입니다.`,
+	TraverseChildren: true,
+}
+
+func init() {
+	volumeCmd.AddCommand(fileCmd)
+}

--- a/cmd/file_add.go
+++ b/cmd/file_add.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
+	"github.com/spf13/cobra"
+)
+
+// fileAddCmd represents the file add command
+var fileAddCmd = &cobra.Command{
+	Use:   "add <volumeId> <filePath>",
+	Short: "볼륨에 파일을 업로드하는 커맨드입니다.",
+	Long:  `로컬 파일을 볼륨의 특정 경로에 업로드합니다.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return cmdError.NewCmdError(1, "볼륨 아이디 혹은 업로드할 파일 경로가 입력되지 않았습니다.")
+		}
+		volumeId := args[0]
+		localFilePath := args[1]
+
+		workspaceId, err := util.GetWorkspaceId(cmd)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		targetPath, err := cmd.Flags().GetString("path")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+		if targetPath == "" {
+			return cmdError.NewCmdError(1, "볼륨 내 저장할 경로가 입력되지 않았습니다.")
+		}
+
+		createDirectory, err := cmd.Flags().GetBool("createDirectory")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		err = exec.UploadVolumeFile(workspaceId, volumeId, localFilePath, targetPath, createDirectory)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	fileCmd.AddCommand(fileAddCmd)
+
+	fileAddCmd.Flags().StringP("path", "p", "", "볼륨 내 저장할 파일 경로")
+	fileAddCmd.Flags().BoolP("directory", "d", false, "상위 디렉토리가 없을 경우 생성 여부")
+}

--- a/cmd/file_add.go
+++ b/cmd/file_add.go
@@ -32,12 +32,12 @@ var fileAddCmd = &cobra.Command{
 			return cmdError.NewCmdError(1, "볼륨 내 저장할 경로가 입력되지 않았습니다.")
 		}
 
-		createDirectory, err := cmd.Flags().GetBool("createDirectory")
+		createDirectory, err := cmd.Flags().GetBool("directory")
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}
 
-		err = exec.UploadVolumeFile(workspaceId, volumeId, localFilePath, targetPath, createDirectory)
+		err = exec.UploadVolumeFile(cmd.Context(), workspaceId, volumeId, localFilePath, targetPath, createDirectory)
 		if err != nil {
 			return cmdError.NewCmdError(1, err.Error())
 		}


### PR DESCRIPTION
## 개요
* 볼륨 리소스에 파일을 삽입하는 커맨드를 추가합니다.
## 작업내용
* multipart 요청 메서드 추가
* 볼륨 파일 업로드 함수 추가
* 볼륨 파일 추가 커맨드 추가
* claude init으로 CLAUDE.md 작성
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 볼륨에 로컬 파일을 업로드하는 `file add` 명령을 추가했습니다.
  * 대상 경로 지정 및 필요한 상위 디렉터리 자동 생성 옵션을 지원합니다.
  * 파일 업로드 과정에서 워크스페이스와 볼륨 정보를 확인하고 오류를 안내합니다.

* **문서**
  * CLI의 목적, 실행 방법, 주요 명령과 파일·상태 관리 구조를 설명하는 안내 문서를 추가했습니다.
  * 운영체제별 제약 사항과 현재 테스트 현황을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->