### PR TITLE
🔀 :: [#282] - 볼륨 내부 파일 제거 커맨드 추가

### DIFF
--- a/api/exec/delete_volume_file.go
+++ b/api/exec/delete_volume_file.go
@@ -1,0 +1,18 @@
+package exec
+
+import "github.com/dolong2/dcd-cli/api"
+
+func DeleteVolumeFile(workspaceId string, volumeId string, targetPath string) error {
+	header := make(map[string]string)
+	accessToken, err := GetAccessToken()
+	if err != nil {
+		return err
+	}
+	header["Authorization"] = "Bearer " + accessToken
+
+	param := make(map[string]string)
+	param["path"] = targetPath
+
+	_, err = api.SendDelete("/"+workspaceId+"/volume/"+volumeId+"/files", header, param)
+	return err
+}

--- a/cmd/file_remove.go
+++ b/cmd/file_remove.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"github.com/dolong2/dcd-cli/api/exec"
+	cmdError "github.com/dolong2/dcd-cli/cmd/err"
+	"github.com/dolong2/dcd-cli/cmd/util"
+	"github.com/spf13/cobra"
+)
+
+// fileRemoveCmd represents the file remove command
+var fileRemoveCmd = &cobra.Command{
+	Use:   "remove <volumeId>",
+	Short: "볼륨에서 파일을 제거하는 커맨드입니다.",
+	Long:  `볼륨의 특정 경로에 있는 파일을 제거합니다.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmdError.NewCmdError(1, "볼륨 아이디가 입력되지 않았습니다.")
+		}
+		volumeId := args[0]
+
+		workspaceId, err := util.GetWorkspaceId(cmd)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		targetPath, err := cmd.Flags().GetString("path")
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+		if targetPath == "" {
+			return cmdError.NewCmdError(1, "볼륨 내 제거할 파일 경로가 입력되지 않았습니다.")
+		}
+
+		err = exec.DeleteVolumeFile(workspaceId, volumeId, targetPath)
+		if err != nil {
+			return cmdError.NewCmdError(1, err.Error())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	fileCmd.AddCommand(fileRemoveCmd)
+
+	fileRemoveCmd.Flags().StringP("path", "p", "", "볼륨에서 제거할 파일 경로")
+}


### PR DESCRIPTION
## 개요
* 볼륨 리소스에 존재하는 파일을 삭제하는 커맨드를 추가합니다.
## 작업내용
* 볼륨 내부 파일 제거 요청 함수 추가
* 볼륨 파일 제거 커맨드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 볼륨 내 파일을 삭제하는 `file remove` 명령을 추가했습니다.
  * 볼륨 ID와 삭제할 경로를 지정해 파일을 삭제할 수 있습니다.
  * 필수 입력값과 API 오류를 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->