### PR TITLE
:twisted_rightwards_arrows: :: [#285] - GithubUrl 네이밍 변경

### DIFF
--- a/api/exec/request/application.go
+++ b/api/exec/request/application.go
@@ -3,7 +3,7 @@ package request
 type ApplicationRequest struct {
 	Name            string   `json:"name"`
 	Description     string   `json:"description"`
-	GithubUrl       string   `json:"githubUrl"`
+	GitRepoUrl      string   `json:"gitRepoUrl"`
 	ApplicationType string   `json:"applicationType"`
 	Port            int      `json:"port"`
 	Version         string   `json:"version"`

--- a/api/exec/response/application.go
+++ b/api/exec/response/application.go
@@ -9,7 +9,7 @@ type ApplicationDetailResponse struct {
 	Name                string            `json:"name"`
 	Description         string            `json:"description"`
 	ApplicationType     string            `json:"applicationType"`
-	GithubUrl           string            `json:"githubUrl"`
+	GitRepoUrl           string           `json:"gitRepoUrl"`
 	Env                 map[string]string `json:"env"`
 	Port                int               `json:"port"`
 	ExternalPort        int               `json:"externalPort"`
@@ -26,7 +26,7 @@ type ApplicationResponse struct {
 	Name            string    `json:"name"`
 	Description     string    `json:"description"`
 	ApplicationType string    `json:"applicationType"`
-	GithubUrl       string    `json:"githubUrl"`
+	GitRepoUrl       string   `json:"gitRepoUrl"`
 	Port            int       `json:"port"`
 	ExternalPort    int       `json:"externalPort"`
 	Version         string    `json:"version"`

--- a/api/exec/template/application.go
+++ b/api/exec/template/application.go
@@ -19,7 +19,7 @@ func (template ApplicationTemplate) validateMetadata() error {
 }
 
 type applicationSpecTemplate struct {
-	GithubUrl       string   `json:"githubUrl" yaml:"githubUrl"`
+	GitRepoUrl      string   `json:"gitRepoUrl" yaml:"gitRepoUrl"`
 	ApplicationType string   `json:"applicationType" yaml:"applicationType"`
 	Port            int      `json:"port" yaml:"port"`
 	Version         string   `json:"version" yaml:"version"`
@@ -36,7 +36,7 @@ func (template ApplicationTemplate) ToRequest() (*request.ApplicationRequest, er
 	return &request.ApplicationRequest{
 		Name:            *template.Metadata.Name,
 		Description:     *template.Metadata.Description,
-		GithubUrl:       template.Spec.GithubUrl,
+		GitRepoUrl:      template.Spec.GitRepoUrl,
 		ApplicationType: template.Spec.ApplicationType,
 		Port:            template.Spec.Port,
 		Version:         template.Spec.Version,

--- a/cmd/util/print_resource.go
+++ b/cmd/util/print_resource.go
@@ -20,7 +20,7 @@ func printApplication(application response.ApplicationDetailResponse) {
 	name := []string{"Name", application.Name}
 	description := []string{"Description", application.Description}
 	applicationType := []string{"Application Type", application.ApplicationType}
-	githubUrl := []string{"GitHub Url", application.GithubUrl}
+	gitRepoUrl := []string{"Git Repo Url", application.GitRepoUrl}
 	port := []string{"Port", strconv.Itoa(application.Port)}
 	externalPort := []string{"External Port", strconv.Itoa(application.ExternalPort)}
 	version := []string{"Version", application.Version}
@@ -32,7 +32,7 @@ func printApplication(application response.ApplicationDetailResponse) {
 	table.Append(name)
 	table.Append(description)
 	table.Append(applicationType)
-	table.Append(githubUrl)
+	table.Append(gitRepoUrl)
 	for _, label := range application.Labels {
 		table.Append([]string{"Label", label})
 	}
@@ -81,7 +81,7 @@ func printApplicationList(applicationList []response.ApplicationResponse) {
 	table.SetAutoWrapText(false)
 	table.SetAlignment(tablewriter.ALIGN_CENTER)
 
-	table.SetHeader([]string{"ID", "Name", "Description", "Application Type", "Github URL", "Port", "External Port", "Version", "Status", "Labels"})
+	table.SetHeader([]string{"ID", "Name", "Description", "Application Type", "Git Repo URL", "Port", "External Port", "Version", "Status", "Labels"})
 
 	for _, application := range applicationList {
 		labels := application.Labels
@@ -99,7 +99,7 @@ func printApplicationList(applicationList []response.ApplicationResponse) {
 			application.Name,
 			application.Description,
 			application.ApplicationType,
-			application.GithubUrl,
+			application.GitRepoUrl,
 			strconv.Itoa(application.Port),
 			strconv.Itoa(application.ExternalPort),
 			application.Version,

--- a/example/json/application/test-application.json
+++ b/example/json/application/test-application.json
@@ -5,7 +5,7 @@
     "description": "application created by json"
   },
   "spec": {
-    "githubUrl": "",
+    "gitRepoUrl": "",
     "applicationType": "REDIS",
     "port": 3306,
     "version": "latest",

--- a/example/yml/application/test-application.yml
+++ b/example/yml/application/test-application.yml
@@ -3,7 +3,7 @@ metadata:
   name: test application with yml
   description: application created by yml
 spec:
-  githubUrl: ''
+  gitRepoUrl: ''
   applicationType: REDIS
   port: 3306
   version: latest


### PR DESCRIPTION
## 개요
* 애플리케이션의 `GithubUrl` 필드를 `GitRepoUrl`로 수정합니다.
## 작업내용
* `Application` `Request`및 `Response`에 `gitRepoUrl` 네이밍 변경
* 테이블 출력 부분에서 네이밍을 `gitRepoUrl`로 변경
* 매니페스트 예시도 `gitRepoUrl` 반영
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] PR 타켓 브랜치가 올바르게 설정되어 있나요?
* [x] PR에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 애플리케이션의 저장소 URL 필드 명칭을 `Git Repo URL`로 통일했습니다.
  * 요청·응답 및 설정 파일에서 `githubUrl` 대신 `gitRepoUrl`을 사용합니다.
  * CLI 출력의 필드명과 표 헤더가 `Git Repo URL`로 변경되었습니다.
  * JSON 및 YAML 예제 파일도 새로운 필드명을 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->